### PR TITLE
IOClass

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_20" default="true" project-jdk-name="18" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_18" default="true" project-jdk-name="18" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,8 +13,11 @@ repositories {
 
 //Wat is dat voor notatie in die strings? Is dit hoe maven central bibliotheken identificeert?
 dependencies {
+    implementation("org.junit.jupiter:junit-jupiter:5.8.1")
+    implementation("org.jetbrains:annotations:24.0.0")
     testImplementation(platform("org.junit:junit-bom:5.9.1"))
     testImplementation("org.junit.jupiter:junit-jupiter")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
 }
 
 //zorgt dat JUnit 5 gebruikt wordt. Zonder dit gaat gradle standaard uit van JUnit 4.

--- a/src/main/java/nl/ou/debm/common/EArchitecture.java
+++ b/src/main/java/nl/ou/debm/common/EArchitecture.java
@@ -1,0 +1,17 @@
+package nl.ou.debm.common;
+
+/**
+ * enumarate CPU-architectures
+ */
+public enum EArchitecture {
+    X64ARCH {
+        public String strFileCode() { return "x64"; }
+    },
+    X86ARCH {
+        public String strFileCode() { return "x86"; }
+    };
+
+    public String strFileCode(){
+        return "";
+    }
+}

--- a/src/main/java/nl/ou/debm/common/ECompiler.java
+++ b/src/main/java/nl/ou/debm/common/ECompiler.java
@@ -1,0 +1,42 @@
+package nl.ou.debm.common;
+
+public enum ECompiler {
+    CLANG {
+        public String strFileCode()             { return "cln"; }
+        public String strCommand()              { return "clang"; }
+        public String strOutputSwitch()         { return "-o";}
+        public String strArchitectureFlag(EArchitecture architecture){
+            return switch (architecture){
+                case X64ARCH -> "-march=x86-64";
+                case X86ARCH -> "-march=native";
+            };
+        }
+        public String strOptFlag(EOptimize optimize){
+            return switch (optimize){
+                case OPTIMIZE -> "-O3";
+                case NO_OPTIMIZE -> "-O0";
+            };
+        }
+    }/*,
+    GCC {
+        public String strFileCode() { return "gcc"; }
+        public String strCommand() { return "gcc"; }
+    }*/;
+
+    public String strFileCode(){
+        return "";
+    }
+    public String strCommand(){
+        return "";
+    }
+
+    public String strArchitectureFlag(EArchitecture architecture){
+        return "";
+    }
+    public String strOutputSwitch(){
+        return "";
+    }
+    public String strOptFlag(EOptimize optimize){
+        return "";
+    }
+}

--- a/src/main/java/nl/ou/debm/common/ECompiler.java
+++ b/src/main/java/nl/ou/debm/common/ECompiler.java
@@ -2,8 +2,15 @@ package nl.ou.debm.common;
 
 public enum ECompiler {
     CLANG {
+        private String strCompilerLocation = "";
         public String strFileCode()             { return "cln"; }
         public String strCommand()              { return "clang"; }
+        public String strCommandLocation() throws Exception {
+            if (strCompilerLocation.isEmpty()){
+                strCompilerLocation = Misc.strGetExternalSoftwareLocation(strCommand());
+            }
+            return strCompilerLocation;
+        }
         public String strOutputSwitch()         { return "-o";}
         public String strArchitectureFlag(EArchitecture architecture){
             return switch (architecture){
@@ -27,6 +34,9 @@ public enum ECompiler {
         return "";
     }
     public String strCommand(){
+        return "";
+    }
+    public String strCommandLocation() throws Exception {
         return "";
     }
 

--- a/src/main/java/nl/ou/debm/common/EOptimize.java
+++ b/src/main/java/nl/ou/debm/common/EOptimize.java
@@ -1,0 +1,14 @@
+package nl.ou.debm.common;
+
+public enum EOptimize {
+    NO_OPTIMIZE {
+        public String strFileCode() { return "nop"; }
+    },
+    OPTIMIZE {
+        public String strFileCode() { return "opt"; }
+    };
+
+    public String strFileCode(){
+        return "";
+    }
+}

--- a/src/main/java/nl/ou/debm/common/IOElements.java
+++ b/src/main/java/nl/ou/debm/common/IOElements.java
@@ -1,0 +1,108 @@
+package nl.ou.debm.common;
+
+import java.io.File;
+
+import static nl.ou.debm.common.Misc.strGetNumberWithPrefixZeros;
+
+/**
+ * This class contains IO-functions. It makes sure that both the producer and the
+ * assessor use the same container structure and the same file names.
+ */
+
+public class IOElements {
+    /*
+        internal rule: any folder return ends with a path separator, OS-dependent
+     */
+
+
+    private static final String binaryPrefix = "binary_";
+    private static final String binaryPostfix = ".exe";
+    private static final String llvmPrefix = "llvm_";
+    private static final String llvmPostfix = ".llvm";
+    private static final String cSourceName = "source.c";
+    private static final String containerFolderPrefix = "container_";
+    private static final String testFolderPrefix = "test_";
+    private static final int numberOfDigits = 3;
+
+
+    private static String m_strBasePath="";
+
+    public static void setBasePath(String strBasePath){
+        m_strBasePath = strAdaptPathToMatchFileSystemAndAddSeparator(strBasePath);
+    }
+    public static String getBasePath(){
+        return m_strBasePath;
+    }
+
+    private static String strAdaptPathToMatchFileSystemAndAddSeparator(String strPath){
+        // empty input?
+        if (strPath.isEmpty()){
+            return strPath;
+        }
+
+        // determine what to look for and what to replace it with
+        char oldChar, newChar;
+        if (File.separatorChar == '/'){
+            oldChar = '\\';
+            newChar = '/';
+        }
+        else{
+            oldChar = '/';
+            newChar = '\\';
+        }
+
+        // make sure correct separator is used
+        strPath = strPath.replace(oldChar, newChar);
+
+        // do we need to add a separator?
+        if (strPath.charAt(strPath.length()-1)!=File.separatorChar){
+            strPath += File.separatorChar;
+        }
+
+        // return the result
+        return strPath;
+    }
+
+
+    public static String strBinaryFullFileName(int iContainer, int iTest, EArchitecture architecture, ECompiler compiler, EOptimize optimize){
+        return strBinaryFullFileName(m_strBasePath, iContainer, iTest, architecture, compiler, optimize);
+    }
+    public static String strBinaryFullFileName(String strBasePath, int iContainer, int iTest, EArchitecture architecture, ECompiler compiler, EOptimize optimize){
+        return strTestFullPath(strBasePath, iContainer, iTest) +
+                strCombineName(binaryPrefix, architecture, compiler, optimize, binaryPostfix);
+    }
+    public static String strLLVMFullFileName(int iContainer, int iTest, EArchitecture architecture, ECompiler compiler, EOptimize optimize){
+        return strLLVMFullFileName(m_strBasePath, iContainer, iTest, architecture, compiler, optimize);
+    }
+    public static String strLLVMFullFileName(String strBasePath, int iContainer, int iTest, EArchitecture architecture, ECompiler compiler, EOptimize optimize){
+        return strTestFullPath(strBasePath, iContainer, iTest) +
+                strCombineName(llvmPrefix, architecture, compiler, optimize, llvmPostfix);
+    }
+    public static String strCSourceFullFilename(int iContainer, int iTest){
+        return strCSourceFullFilename(m_strBasePath, iContainer, iTest);
+    }
+    public static String strCSourceFullFilename(String strBasePath, int iContainer, int iTest){
+        return strTestFullPath(strBasePath, iContainer, iTest) + cSourceName;
+    }
+
+    private static String strCombineName(String strPrefix, EArchitecture architecture, ECompiler compiler, EOptimize optimize, String strPostfix){
+        return strPrefix + architecture.strFileCode() + "_" +
+                compiler.strFileCode() + "_" +
+                optimize.strFileCode() +
+                strPostfix;
+    }
+    public static String strContainerFullPath(int iContainer){
+        return strContainerFullPath(m_strBasePath, iContainer);
+    }
+    public static String strContainerFullPath(String strBasePath, int iContainer){
+        return strAdaptPathToMatchFileSystemAndAddSeparator(strBasePath) +
+                containerFolderPrefix + strGetNumberWithPrefixZeros(iContainer, numberOfDigits) + File.separatorChar;
+    }
+    public static String strTestFullPath(int iContainer, int iTest){
+        return strTestFullPath(m_strBasePath, iContainer, iTest);
+    }
+    public static String strTestFullPath(String strBasePath, int iContainer, int iTest){
+        return strContainerFullPath(strBasePath, iContainer) +
+                testFolderPrefix + strGetNumberWithPrefixZeros(iTest, numberOfDigits) + File.separatorChar ;
+    }
+}

--- a/src/main/java/nl/ou/debm/common/Misc.java
+++ b/src/main/java/nl/ou/debm/common/Misc.java
@@ -1,0 +1,92 @@
+package nl.ou.debm.common;
+
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+
+import static java.lang.Math.abs;
+import static java.lang.Math.max;
+
+/**
+ * Class containing all kinds of miscellaneous functions
+ */
+
+
+public class Misc {
+    /**
+     * Convert an integer to a string with a fixed length, using zero as
+     * pre-character. strGetNumberWithPrefixZeros(23, 4) results in "0023"
+     * Negative numbers are inverted to positive numbers. If more digits
+     * are needed, because of the height of the value, a longer string will
+     * be returened. strGetNumberWithPrefixZeros(123456, 4) will still return "123456"
+     * @param iValue  Value to be converted to a string. Negative numbers will be
+     *                inverted
+     * @param iLength Number of digits requested.
+     * @return        String of the requested length (or longer, if iValue is too big),
+     *                using "0" as prefix char.
+     */
+    public static String strGetNumberWithPrefixZeros(int iValue, int iLength){
+        // avoid negative input
+        iValue = abs(iValue);
+        // calculate length
+        iLength = max(("" + iValue).length(), iLength);
+        // initial conversion:
+        // ten zeros are enough, considering the maximum value of an integer
+        String strTmp = "000000000" + iValue;
+        // ...but, hey, if a user wants a 20-digit string, who are we to defy?
+        while ((strTmp.length()-iLength)<0) {
+            // this will result in a zero-adding loop, causing some garbage issues
+            // however, since this part of the program will quite likely not be
+            // called very often and since it adds ten digits per loop, the
+            // overhead is acceptable.
+            strTmp = "0000000000" + strTmp;
+        }
+        // return the proper result
+        return strTmp.substring(strTmp.length()-iLength);
+    }
+
+    /**
+     * Get the base-folder for the containers, based on Linux-arch (Jaaps PC) or
+     * Windows-arch (Reijers PC/Kesava's PC)
+     * @return  base folder for containers
+     * TODO: implement Kesava's PC
+     */
+    public static String strGetContainersBaseFolder(){
+        // TODO: Find a nicer debug-solution
+
+        if (File.separatorChar == '/'){
+            // assume: Jaap
+            return "/home/jaap/VAF/containers/";
+        }
+        else{
+            return "C:\\Users\\reije\\OneDrive\\Documenten\\Development\\c-program\\containers\\";
+        }
+    }
+
+    private static boolean bRunsOnWindows(){
+        return (File.separatorChar == '\\');
+    }
+    private static boolean bRunsOnLinux(){
+        return (File.separatorChar == '/');
+    }
+    public static String strGetExternalSoftwareLocation(String softwareName) throws Exception {
+        String command;
+        if (bRunsOnWindows()){
+            command = "where";
+        }
+        else if (bRunsOnLinux()){
+            command = "which";
+        }
+        else {
+            throw new Exception("Cannot determine Windows or Linux");
+        }
+        var whereSoftware = new ProcessBuilder(command, softwareName).redirectErrorStream(true).start();
+        var softwareLocation = new BufferedReader(new InputStreamReader(whereSoftware.getInputStream())).readLine();
+        if (softwareLocation == null){
+            throw new Exception("Cannot find requested software: " + softwareName);
+        }
+        return softwareLocation;
+    }
+
+}

--- a/src/main/java/nl/ou/debm/producer/EFeaturePrefix.java
+++ b/src/main/java/nl/ou/debm/producer/EFeaturePrefix.java
@@ -1,8 +1,10 @@
 package nl.ou.debm.producer;
 
+/**
+ *     enumerate feature prefixes
+ *     this enables testing for duplicates and reversing a code to a constant
+ */
 public enum EFeaturePrefix {
-    // enumerate feature prefixes
-    // this enables testing for duplicates and reversing a code to a constant
     FUNCTIONFEATURE         { public String toString() { return "FF";} },
     DATASTRUCTUREFEATURE    { public String toString() { return "DS";} },
     CONTROLFLOWFEATURE      { public String toString() { return "CF";} };

--- a/src/main/java/nl/ou/debm/producer/Main.java
+++ b/src/main/java/nl/ou/debm/producer/Main.java
@@ -1,27 +1,31 @@
 package nl.ou.debm.producer;
 
-import java.io.*;
-import java.nio.file.Paths;
+import nl.ou.debm.common.*;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class Main {
     public static void main(String[] args) throws Exception {
 
-        var amountOfContainers = 2;
-        var amountOfSources = 3;
+        final var amountOfContainers = 2;
+        final var amountOfSources = 3;
 
         //1. Initialize folder structure
-        var containersFolder = new File("C:\\Users\\reije\\OneDrive\\Documenten\\Development\\c-program\\containers");
+        // set base path for all container operations, use a hack to differentiate between Reijer & Jaap & Kesava
+        IOElements.setBasePath(Misc.strGetContainersBaseFolder());
+        var containersFolder = new File(IOElements.getBasePath());
         if (!containersFolder.exists() && !containersFolder.mkdirs())
             throw new Exception("Unable to create containers folder");
 
         for (var containerIndex = 0; containerIndex < amountOfContainers; containerIndex++) {
             //2. Make package folder structure
-            var containerFolderPath = Paths.get(containersFolder.getAbsolutePath(), "container_"+containerIndex).toString();
+            var containerFolderPath = IOElements.strContainerFullPath(containerIndex);
             var containerFolder = new File(containerFolderPath);
             if (!containerFolder.exists() && !containerFolder.mkdirs())
                 throw new Exception("Unable to create package folder" + containerIndex);
@@ -29,52 +33,104 @@ public class Main {
             //3. Generate C-sources
             var EXEC = Executors.newCachedThreadPool();
             var tasks = new ArrayList<Callable<String>>();
-            for (var i = 0; i < amountOfSources; i++) {
-                var testFolderPath = Paths.get(containerFolderPath, "test_"+i).toString();
+            for (var testIndex = 0; testIndex < amountOfSources; testIndex++) {
+                var testFolderPath = IOElements.strTestFullPath(containerIndex, testIndex);
                 var testFolder = new File(testFolderPath);
                 if (!testFolder.exists() && !testFolder.mkdirs())
-                    throw new Exception("Unable to create test folder" + i);
+                    throw new Exception("Unable to create test folder" + testIndex);
 
-                var sourceFilePath = Paths.get(testFolderPath, "source.c").toString();
+                var sourceFilePath = IOElements.strCSourceFullFilename(containerIndex, testIndex);
                 new CGenerator().generateSourceFile(sourceFilePath);
 
-                //4. Call CLang compiler
-                var whereClang = new ProcessBuilder("where", "clang").redirectErrorStream(true).start();
-                var cLangLocation = new BufferedReader(new InputStreamReader(whereClang.getInputStream())).readLine();
-                System.out.println("Found clang at " + cLangLocation);
-                var clangMarchs = new String[]{"x86-64", "native"};
-                var clangOFlags = new String[]{"-O0", "-O3"};
-                for (var march : clangMarchs) {
-                    for (var oFlag : clangOFlags) {
-                        var binaryPath = Paths.get(testFolderPath,"clang_" + march + oFlag + ".exe").toString();
-                        var llvmPath = Paths.get(testFolderPath,"clang_" + march + oFlag + ".llvm").toString();
-                        //Generate binary
-                        tasks.add(() -> {
-                            var ps = new ProcessBuilder(cLangLocation, sourceFilePath, "-o", binaryPath, "-march="+march, oFlag);
-                            ps.redirectErrorStream(true);
-                            var compilationProcess = ps.start();
-                            var reader = new BufferedReader(new InputStreamReader(compilationProcess.getInputStream()));
-                            String line;
-                            while ((line = reader.readLine()) != null) {
-                                System.out.println(line);
-                            }
-                            compilationProcess.waitFor();
-                            return binaryPath;
-                        });
-                        //Generate LLVM
-                        tasks.add(() -> {
-                            var ps = new ProcessBuilder(cLangLocation, sourceFilePath, "-S", "-emit-llvm", "-o", llvmPath, "-march="+march, oFlag);
-                            ps.redirectErrorStream(true);
-                            var compilationProcess = ps.start();
-                            var reader = new BufferedReader(new InputStreamReader(compilationProcess.getInputStream()));
-                            String line;
-                            while ((line = reader.readLine()) != null) {
-                                System.out.println(line);
-                            }
-                            compilationProcess.waitFor();
-                            return llvmPath;
-                        });
+                //4. call compiler(s)
+                for (var compiler : ECompiler.values()) {
+                    var cLangLocation = Misc.strGetExternalSoftwareLocation(compiler.strCommand());
+                    System.out.println("Found " + compiler.strCommand() + " at " + cLangLocation);
+
+//                    var clangMarchs = new String[]{"x86-64", "native"};
+//                    var clangOFlags = new String[]{"-O0", "-O3"};
+                    AtomicInteger c= new AtomicInteger();
+                    for (var architecture : EArchitecture.values()) {
+                        for (var optimize : EOptimize.values()) {
+                            var binaryPath = IOElements.strBinaryFullFileName(containerIndex, testIndex, architecture, compiler, optimize);
+                            var llvmPath = IOElements.strLLVMFullFileName(containerIndex, testIndex, architecture, compiler, optimize);
+                            //Generate binary
+                            tasks.add(() -> {
+                                int q= c.incrementAndGet();
+                                var ps = new ProcessBuilder(cLangLocation,
+                                                            sourceFilePath,
+                                                            compiler.strOutputSwitch(),
+                                                            compiler.strArchitectureFlag(architecture),
+                                                            compiler.strOptFlag(optimize));
+                                ps.redirectErrorStream(true);
+                                var compilationProcess = ps.start();
+                                var reader = new BufferedReader(new InputStreamReader(compilationProcess.getInputStream()));
+                                String line;
+                                while ((line = reader.readLine()) != null) {
+                                    System.out.println("*" + q + " " + line);
+                                }
+                                compilationProcess.waitFor();
+                                return binaryPath;
+                            });
+                            //Generate LLVM
+                            tasks.add(() -> {
+                                int q= c.incrementAndGet();
+                                var ps = new ProcessBuilder(cLangLocation,
+                                                            sourceFilePath, "-S", "-emit-llvm",
+                                                            compiler.strOutputSwitch(),
+                                                            llvmPath,
+                                                            compiler.strArchitectureFlag(architecture),
+                                                            compiler.strOptFlag(optimize));
+                                ps.redirectErrorStream(true);
+                                var compilationProcess = ps.start();
+                                var reader = new BufferedReader(new InputStreamReader(compilationProcess.getInputStream()));
+                                String line;
+                                while ((line = reader.readLine()) != null) {
+                                    System.out.println("|" + q + " " + line);
+                                }
+                                compilationProcess.waitFor();
+                                return llvmPath;
+                            });
+                        }
                     }
+
+
+
+
+//                    var clangMarchs = new String[]{"x86-64", "native"};
+//                    var clangOFlags = new String[]{"-O0", "-O3"};
+//                    for (var march : clangMarchs) {
+//                        for (var oFlag : clangOFlags) {
+//                            var binaryPath = Paths.get(testFolderPath, "clang_" + march + oFlag + ".exe").toString();
+//                            var llvmPath = Paths.get(testFolderPath, "clang_" + march + oFlag + ".llvm").toString();
+//                            //Generate binary
+//                            tasks.add(() -> {
+//                                var ps = new ProcessBuilder(cLangLocation, sourceFilePath, "-o", binaryPath, "-march=" + march, oFlag);
+//                                ps.redirectErrorStream(true);
+//                                var compilationProcess = ps.start();
+//                                var reader = new BufferedReader(new InputStreamReader(compilationProcess.getInputStream()));
+//                                String line;
+//                                while ((line = reader.readLine()) != null) {
+//                                    System.out.println(line);
+//                                }
+//                                compilationProcess.waitFor();
+//                                return binaryPath;
+//                            });
+//                            //Generate LLVM
+//                            tasks.add(() -> {
+//                                var ps = new ProcessBuilder(cLangLocation, sourceFilePath, "-S", "-emit-llvm", "-o", llvmPath, "-march=" + march, oFlag);
+//                                ps.redirectErrorStream(true);
+//                                var compilationProcess = ps.start();
+//                                var reader = new BufferedReader(new InputStreamReader(compilationProcess.getInputStream()));
+//                                String line;
+//                                while ((line = reader.readLine()) != null) {
+//                                    System.out.println(line);
+//                                }
+//                                compilationProcess.waitFor();
+//                                return llvmPath;
+//                            });
+//                        }
+//                    }
                 }
                 var results = EXEC.invokeAll(tasks);
             }

--- a/src/main/java/nl/ou/debm/test/MiscTest.java
+++ b/src/main/java/nl/ou/debm/test/MiscTest.java
@@ -1,0 +1,93 @@
+package nl.ou.debm.test;
+
+import nl.ou.debm.common.Misc;
+import org.junit.jupiter.api.Test;
+
+import static nl.ou.debm.common.Misc.strGetNumberWithPrefixZeros;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MiscTest {
+
+    @org.junit.jupiter.api.Test
+    void strGetNumberWithPrefixZerosTest() {
+        int len = 0;
+        assertEquals("0", strGetNumberWithPrefixZeros(0,len));
+        assertEquals("1", strGetNumberWithPrefixZeros(1,len));
+        assertEquals("9", strGetNumberWithPrefixZeros(9,len));
+        assertEquals("10", strGetNumberWithPrefixZeros(10,len));
+        assertEquals("15", strGetNumberWithPrefixZeros(15,len));
+        assertEquals("23", strGetNumberWithPrefixZeros(23,len));
+        assertEquals("99", strGetNumberWithPrefixZeros(99,len));
+        assertEquals("100", strGetNumberWithPrefixZeros(100,len));
+        
+        len = 1;
+        assertEquals("0", strGetNumberWithPrefixZeros(0,len));
+        assertEquals("1", strGetNumberWithPrefixZeros(1,len));
+        assertEquals("9", strGetNumberWithPrefixZeros(9,len));
+        assertEquals("10", strGetNumberWithPrefixZeros(10,len));
+        assertEquals("15", strGetNumberWithPrefixZeros(15,len));
+        assertEquals("23", strGetNumberWithPrefixZeros(23,len));
+        assertEquals("99", strGetNumberWithPrefixZeros(99,len));
+        assertEquals("100", strGetNumberWithPrefixZeros(100,len));
+
+        len = 2;
+        assertEquals("00", strGetNumberWithPrefixZeros(0,len));
+        assertEquals("01", strGetNumberWithPrefixZeros(1,len));
+        assertEquals("09", strGetNumberWithPrefixZeros(9,len));
+        assertEquals("10", strGetNumberWithPrefixZeros(10,len));
+        assertEquals("15", strGetNumberWithPrefixZeros(15,len));
+        assertEquals("23", strGetNumberWithPrefixZeros(23,len));
+        assertEquals("99", strGetNumberWithPrefixZeros(99,len));
+        assertEquals("100", strGetNumberWithPrefixZeros(100,len));
+
+        len = 3;
+        assertEquals("000", strGetNumberWithPrefixZeros(0,len));
+        assertEquals("001", strGetNumberWithPrefixZeros(1,len));
+        assertEquals("009", strGetNumberWithPrefixZeros(9,len));
+        assertEquals("010", strGetNumberWithPrefixZeros(10,len));
+        assertEquals("015", strGetNumberWithPrefixZeros(15,len));
+        assertEquals("023", strGetNumberWithPrefixZeros(23,len));
+        assertEquals("099", strGetNumberWithPrefixZeros(99,len));
+        assertEquals("100", strGetNumberWithPrefixZeros(100,len));
+
+        len = 29;
+        assertEquals("00000000000000000000000000000", strGetNumberWithPrefixZeros(0,len));
+        assertEquals("00000000000000000000000000001", strGetNumberWithPrefixZeros(1,len));
+        assertEquals("00000000000000000000000000009", strGetNumberWithPrefixZeros(9,len));
+        assertEquals("00000000000000000000000000010", strGetNumberWithPrefixZeros(10,len));
+        assertEquals("00000000000000000000000000015", strGetNumberWithPrefixZeros(15,len));
+        assertEquals("00000000000000000000000000023", strGetNumberWithPrefixZeros(23,len));
+        assertEquals("00000000000000000000000000099", strGetNumberWithPrefixZeros(99,len));
+        assertEquals("00000000000000000000000000100", strGetNumberWithPrefixZeros(100,len));
+
+        len = 30;
+        assertEquals("000000000000000000000000000000", strGetNumberWithPrefixZeros(0,len));
+        assertEquals("000000000000000000000000000001", strGetNumberWithPrefixZeros(1,len));
+        assertEquals("000000000000000000000000000009", strGetNumberWithPrefixZeros(9,len));
+        assertEquals("000000000000000000000000000010", strGetNumberWithPrefixZeros(10,len));
+        assertEquals("000000000000000000000000000015", strGetNumberWithPrefixZeros(15,len));
+        assertEquals("000000000000000000000000000023", strGetNumberWithPrefixZeros(23,len));
+        assertEquals("000000000000000000000000000099", strGetNumberWithPrefixZeros(99,len));
+        assertEquals("000000000000000000000000000100", strGetNumberWithPrefixZeros(100,len));
+
+        len = 31;
+        assertEquals("0000000000000000000000000000000", strGetNumberWithPrefixZeros(0,len));
+        assertEquals("0000000000000000000000000000001", strGetNumberWithPrefixZeros(1,len));
+        assertEquals("0000000000000000000000000000009", strGetNumberWithPrefixZeros(9,len));
+        assertEquals("0000000000000000000000000000010", strGetNumberWithPrefixZeros(10,len));
+        assertEquals("0000000000000000000000000000015", strGetNumberWithPrefixZeros(15,len));
+        assertEquals("0000000000000000000000000000023", strGetNumberWithPrefixZeros(23,len));
+        assertEquals("0000000000000000000000000000099", strGetNumberWithPrefixZeros(99,len));
+        assertEquals("0000000000000000000000000000100", strGetNumberWithPrefixZeros(100,len));
+    }
+
+    @Test
+    void strGetExternalSoftwareLocationTest() {
+        assertThrows(Exception.class, () -> {
+            var location = Misc.strGetExternalSoftwareLocation("dezesoftwarebestaatniet");
+        });
+        assertDoesNotThrow(() -> {
+            var location = Misc.strGetExternalSoftwareLocation("clang");
+        });
+    }
+}


### PR DESCRIPTION
In order to generalize, I wrote IOElements, which creates the proper path- and filenames for the containers and files, given:
- container number
- test number
- compiler/architecture/optimization
- llvm/exe/c
This enables both producer and assessor to easily access the same files and folders, while also taking care of the /-\-battle that continues between Win and Linux.

The changes in the main production loop look far worse than they feel. I didn't rewrite the loop, but I had to rewrite the parts that assembled the command line for the invocation and I wanted to do so while having the old version commented out. That's why it's coloured that much.