### PR TITLE
Assessor starting with parameter

### DIFF
--- a/scripts/run-retdec.bat
+++ b/scripts/run-retdec.bat
@@ -4,5 +4,4 @@ IF "%1" EQU "" (
   exit /b 1
 )
 
-C:\Users\reije\Downloads\RetDec-v5.0-Windows-Release\bin\retdec-decompiler.exe %1%
-echo CFILE=%~dp0%program.exe.c
+C:\Users\reije\Downloads\RetDec-v5.0-Windows-Release\bin\retdec-decompiler.exe %1 -o %2

--- a/src/main/java/nl/ou/debm/assessor/Assessor.java
+++ b/src/main/java/nl/ou/debm/assessor/Assessor.java
@@ -69,7 +69,7 @@ public class Assessor {
                     for (var opt : EOptimize.values()) {
                         // setup values
                         var strBinary = strBinaryFullFileName(iContainerNumber, iTestNumber, architecture, compiler, opt);
-                        var strCDest = tempDir + STRCDECOMP;
+                        var strCDest = Paths.get(tempDir.toString(), STRCDECOMP).toAbsolutePath().toString();
                         // setup new process
                         var decompileProcessBuilder = new ProcessBuilder(
                                 strDecompileScript,
@@ -128,7 +128,7 @@ public class Assessor {
         // TODO: Implement getting a container number from anywhere
         //       (command line input, random something, whatever)
         //       for now: just return 1 for test purposes
-        return 1;
+        return 0;
     }
 
     /**

--- a/src/main/java/nl/ou/debm/assessor/Main.java
+++ b/src/main/java/nl/ou/debm/assessor/Main.java
@@ -8,6 +8,7 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
 
 import java.io.IOException;
+import java.security.InvalidParameterException;
 
 import static nl.ou.debm.common.IOElements.strAdaptPathToMatchFileSystemAndAddSeparator;
 import static nl.ou.debm.common.Misc.strGetContainersBaseFolder;
@@ -15,8 +16,11 @@ import static nl.ou.debm.common.Misc.strGetContainersBaseFolder;
 public class Main {
 
     public static void main(String[] args) throws Exception {
+        if(args.length != 1)
+            throw new InvalidParameterException("Program can only be run with exactly one argument!");
+
         var ass = new Assessor();
         ass.RunTheTests(strGetContainersBaseFolder(),
-                strAdaptPathToMatchFileSystemAndAddSeparator(strGetContainersBaseFolder()) + "decompile.sh");
+                args[0]);
     }
 }

--- a/src/main/java/nl/ou/debm/common/feature1/ControlFlowFeature.java
+++ b/src/main/java/nl/ou/debm/common/feature1/ControlFlowFeature.java
@@ -1,6 +1,7 @@
 package nl.ou.debm.common.feature1;
 
 import nl.ou.debm.common.IAssessor;
+import nl.ou.debm.common.antlr.CVisitor;
 import nl.ou.debm.common.antlr.MyCListener;
 import nl.ou.debm.producer.CGenerator;
 import nl.ou.debm.producer.EFeaturePrefix;
@@ -50,13 +51,15 @@ public class ControlFlowFeature implements  IFeature, IAssessor, IStatementGener
 
     @Override
     public SingleTestResult GetSingleTestResult(Codeinfo ci) {
+/*
 
         var tree = ci.cparser_dec.compilationUnit();
 
-        var listener = new MyCListener();
+        var listener = new CVisitor().visit(ci.cparser_dec.compilationUnit());
         var walker = new ParseTreeWalker();
         walker.walk(listener, tree);
 
+*/
 
         return null;
     }


### PR DESCRIPTION
The assessor can now be started with the decompile script as program argument.
This is the goal of the assessor: calling it with a decompile script as argument.

Ook retdec.bat aangepast, zodat hij het doelbestand aan retdec meegeeft.
Code van feature 1 in de assessor uitgecomment, anders bleef die eindeloos draaien (LLVMvisitor)
Op windows wordt het tempbestand niet geëindigd met een slash, daarom Paths.get gebruikt om het pad kloppend te maken