### PR TITLE
Statementswithprefs

### DIFF
--- a/src/main/java/nl/ou/debm/common/ProjectSettings.java
+++ b/src/main/java/nl/ou/debm/common/ProjectSettings.java
@@ -12,4 +12,6 @@ public class ProjectSettings {
     public static final double CHANCE_OF_TERMINATION_EXPRESSION_RECURSION = 0.5;
     public static final double CHANCE_OF_STRUCT_WHEN_ASKING_FOR_RANDOM_DATATYPE = 0.5;
     public static final int MAX_EXPRESSION_DEPTH = 5;
+    public static final double CHANCE_OF_MULTIPLE_STATEMENTS=.01;
+    public static final int MAX_MUTLIPLE_STATEMENTS=10;
 }

--- a/src/main/java/nl/ou/debm/common/feature1/ControlFlowFeature.java
+++ b/src/main/java/nl/ou/debm/common/feature1/ControlFlowFeature.java
@@ -59,12 +59,12 @@ public class ControlFlowFeature implements  IFeature, IAssessor, IStatementGener
     }
 
     @Override
-    public List<String> getNewStatement() {
-        return getNewStatement(null);
+    public List<String> getNewStatements() {
+        return getNewStatements(null);
     }
 
     @Override
-    public List<String> getNewStatement(StatementPrefs prefs) {
+    public List<String> getNewStatements(StatementPrefs prefs) {
         // check prefs object
         if (prefs == null){
             prefs = new StatementPrefs(null);
@@ -103,9 +103,9 @@ public class ControlFlowFeature implements  IFeature, IAssessor, IStatementGener
         // still a stub but makesomething of it
         var forloop = new ForLoop("int c=0", "c<10", "++c");
 
-        list.add("printf(\\\"\" + forloop.toCodeMarker() + \"\\\");");
+        list.add("printf(\"" + forloop.toCodeMarker() + "\");");
         list.add(forloop.strGetForStatement(true));
-        list.add("   print(\"loopvar = %d\", c)");
+        list.add("   printf(\"loopvar = %d;\", c);");
         list.add("}");
 
         m_iNForLoops++;

--- a/src/main/java/nl/ou/debm/common/feature1/ControlFlowFeature.java
+++ b/src/main/java/nl/ou/debm/common/feature1/ControlFlowFeature.java
@@ -1,13 +1,7 @@
 package nl.ou.debm.common.feature1;
 
 import nl.ou.debm.common.IAssessor;
-import nl.ou.debm.common.antlr.CVisitor;
-import nl.ou.debm.common.antlr.MyCListener;
-import nl.ou.debm.producer.CGenerator;
-import nl.ou.debm.producer.EFeaturePrefix;
-import nl.ou.debm.producer.IFeature;
-import nl.ou.debm.producer.IStatementGenerator;
-import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import nl.ou.debm.producer.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -65,9 +59,24 @@ public class ControlFlowFeature implements  IFeature, IAssessor, IStatementGener
     }
 
     @Override
-    public String getNewStatement() {
+    public List<String> getNewStatement() {
+        return getNewStatement(null);
+    }
+
+    @Override
+    public List<String> getNewStatement(StatementPrefs prefs) {
+        // check prefs object
+        if (prefs == null){
+            prefs = new StatementPrefs(null);
+        }
+
+        // **** as this is a stub, forget about preferences and just return something *****
+
+
         var forloop = new ForLoop("int c=0", "c<10", "++c");
         m_iNForLoops++;
-        return forloop.strGetForStatement() + "{ printf(\"" + forloop.toCodeMarker() + "\"); }";
+        var list = new ArrayList<String>();
+        list.add(forloop.strGetForStatement() + "{ printf(\"" + forloop.toCodeMarker() + "\"); }");
+        return list;
     }
 }

--- a/src/main/java/nl/ou/debm/common/feature1/ControlFlowFeature.java
+++ b/src/main/java/nl/ou/debm/common/feature1/ControlFlowFeature.java
@@ -70,13 +70,45 @@ public class ControlFlowFeature implements  IFeature, IAssessor, IStatementGener
             prefs = new StatementPrefs(null);
         }
 
-        // **** as this is a stub, forget about preferences and just return something *****
-
-
-        var forloop = new ForLoop("int c=0", "c<10", "++c");
-        m_iNForLoops++;
+        // create list
         var list = new ArrayList<String>();
-        list.add(forloop.strGetForStatement() + "{ printf(\"" + forloop.toCodeMarker() + "\"); }");
+
+        // can we oblige?
+        if (prefs.loop == EStatementPref.NOT_WANTED){
+            // no, as we only produce loops
+            return list;
+        }
+        if (prefs.numberOfStatements == ENumberOfStatementsPref.SINGLE){
+            // no, as we only produce multiple statements
+            return list;
+        }
+        if (prefs.expression == EStatementPref.REQUIRED){
+            // no, as we do not do expressions
+            return list;
+        }
+        if (prefs.assignment == EStatementPref.REQUIRED){
+            // no, as we do not do assignments
+            return list;
+        }
+        if (prefs.compoundStatement == EStatementPref.NOT_WANTED){
+            // no, as we use a compound statement as loop body
+            return list;
+        }
+
+        // we have now asserted that:
+        // - loops, multiple statements and compound statements are  allowed or required
+        // - expressions and assignments are not required
+
+
+        // still a stub but makesomething of it
+        var forloop = new ForLoop("int c=0", "c<10", "++c");
+
+        list.add("printf(\\\"\" + forloop.toCodeMarker() + \"\\\");");
+        list.add(forloop.strGetForStatement(true));
+        list.add("   print(\"loopvar = %d\", c)");
+        list.add("}");
+
+        m_iNForLoops++;
         return list;
     }
 }

--- a/src/main/java/nl/ou/debm/common/feature2/DataStructuresFeature.java
+++ b/src/main/java/nl/ou/debm/common/feature2/DataStructuresFeature.java
@@ -18,12 +18,12 @@ public class DataStructuresFeature implements IFeature, IStatementGenerator, ISt
     }
 
     @Override
-    public List<String> getNewStatement() {
-        return getNewStatement(null);
+    public List<String> getNewStatements() {
+        return getNewStatements(null);
     }
 
     @Override
-    public List<String> getNewStatement(StatementPrefs prefs) {
+    public List<String> getNewStatements(StatementPrefs prefs) {
         // check preferences object
         if (prefs==null){
             prefs = new StatementPrefs(null);

--- a/src/main/java/nl/ou/debm/common/feature2/DataStructuresFeature.java
+++ b/src/main/java/nl/ou/debm/common/feature2/DataStructuresFeature.java
@@ -2,6 +2,7 @@ package nl.ou.debm.common.feature2;
 
 import nl.ou.debm.producer.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class DataStructuresFeature implements IFeature, IStatementGenerator, IStructGenerator, IGlobalVariableGenerator {
@@ -17,8 +18,22 @@ public class DataStructuresFeature implements IFeature, IStatementGenerator, ISt
     }
 
     @Override
-    public String getNewStatement() {
-        return "int " + getPrefix() + "_" + variableCount++ + " = 3;\n";
+    public List<String> getNewStatement() {
+        return getNewStatement(null);
+    }
+
+    @Override
+    public List<String> getNewStatement(StatementPrefs prefs) {
+        // check preferences object
+        if (prefs==null){
+            prefs = new StatementPrefs(null);
+        }
+
+        // this is a stub, so forget about preferences and just return something
+        // TODO: expand stub
+        var list = new ArrayList<String>();
+        list.add("int " + getPrefix() + "_" + variableCount++ + " = 3;\n");
+        return list;
     }
 
     @Override

--- a/src/main/java/nl/ou/debm/common/feature3/FunctionFeature.java
+++ b/src/main/java/nl/ou/debm/common/feature3/FunctionFeature.java
@@ -92,9 +92,12 @@ public class FunctionFeature implements IFeature, IExpressionGenerator, IFunctio
         while((withParameters == null || withParameters == true) && Math.random() < 0.7)
             result.addParameter(new FunctionParameter("p" + parameterCount++, generator.getDataType()));
 
-        result.addStatement(generator.getNewStatement());
-        result.addStatement(generator.getNewStatement());
-        result.addStatement(generator.getNewStatement());
+        // prefer exact one statement
+        var prefs = new StatementPrefs();
+        assert generator != null;
+        result.addStatement(generator.getNewStatement(prefs).get(0));
+        result.addStatement(generator.getNewStatement(prefs).get(0));
+        result.addStatement(generator.getNewStatement(prefs).get(0));
 
         if(tailCallCount < 10){
             tailCallCount++;

--- a/src/main/java/nl/ou/debm/common/feature3/FunctionFeature.java
+++ b/src/main/java/nl/ou/debm/common/feature3/FunctionFeature.java
@@ -92,12 +92,13 @@ public class FunctionFeature implements IFeature, IExpressionGenerator, IFunctio
         while((withParameters == null || withParameters == true) && Math.random() < 0.7)
             result.addParameter(new FunctionParameter("p" + parameterCount++, generator.getDataType()));
 
-        // prefer exact one statement
-        var prefs = new StatementPrefs();
+        // add three statements
+        // prefer exactly one statement per call
+        var prefs = new StatementPrefs();       // default statements: single statement, no compound or loop
         assert generator != null;
-        result.addStatement(generator.getNewStatement(prefs).get(0));
-        result.addStatement(generator.getNewStatement(prefs).get(0));
-        result.addStatement(generator.getNewStatement(prefs).get(0));
+        result.addStatement(generator.getNewStatement(prefs));
+        result.addStatement(generator.getNewStatement(prefs));
+        result.addStatement(generator.getNewStatement(prefs));
 
         if(tailCallCount < 10){
             tailCallCount++;

--- a/src/main/java/nl/ou/debm/common/feature3/FunctionFeature.java
+++ b/src/main/java/nl/ou/debm/common/feature3/FunctionFeature.java
@@ -96,9 +96,9 @@ public class FunctionFeature implements IFeature, IExpressionGenerator, IFunctio
         // prefer exactly one statement per call
         var prefs = new StatementPrefs();       // default statements: single statement, no compound or loop
         assert generator != null;
-        result.addStatement(generator.getNewStatement(prefs));
-        result.addStatement(generator.getNewStatement(prefs));
-        result.addStatement(generator.getNewStatement(prefs));
+        result.addStatements(generator.getNewStatements(prefs));
+        result.addStatements(generator.getNewStatements(prefs));
+        result.addStatements(generator.getNewStatements(prefs));
 
         if(tailCallCount < 10){
             tailCallCount++;

--- a/src/main/java/nl/ou/debm/producer/CGenerator.java
+++ b/src/main/java/nl/ou/debm/producer/CGenerator.java
@@ -305,6 +305,10 @@ public class CGenerator {
                 if (!(prefs.expression == EStatementPref.NOT_WANTED)){
                     list.add(getNewExpression(1, getDataType()) + ";\n");
                 }
+                else{
+                    // prevent infinite loops
+                    break;
+                }
             }
 
             // as the list will grow, this loop will stop sooner or later

--- a/src/main/java/nl/ou/debm/producer/CGenerator.java
+++ b/src/main/java/nl/ou/debm/producer/CGenerator.java
@@ -271,9 +271,12 @@ public class CGenerator {
                         // if multiple statements were requested, the list.size() loop will make sure that there
                         // are at least two statements. Therefor, in this case, if a feature returns only
                         // one statement, it is ok
-                        var p2=prefs;
+                        var p2=new StatementPrefs(prefs);
                         if (iNumberOfStatements>1){
                             p2.numberOfStatements=ENumberOfStatementsPref.DON_T_CARE;
+                        }
+                        else{
+                            p2.numberOfStatements=ENumberOfStatementsPref.SINGLE;
                         }
 
                         // get statement(s) from feature class

--- a/src/main/java/nl/ou/debm/producer/CGenerator.java
+++ b/src/main/java/nl/ou/debm/producer/CGenerator.java
@@ -122,7 +122,7 @@ public class CGenerator {
         // the main function may, in the end, turn out to be very short:
         // it may even have only one line!
         while (!allFeaturesSatisfied()) {
-            mainFunction.addStatements(getNewStatement());
+            mainFunction.addStatements(getNewStatements());
         }
 
         // Use standard exit code as a last statement
@@ -208,8 +208,8 @@ public class CGenerator {
      * an expression (see: getNewExpression).
      * @return   list of Strings containing one or more statements
      */
-    public List<String> getNewStatement() {
-        return getNewStatement(null);
+    public List<String> getNewStatements() {
+        return getNewStatements(null);
     }
 
     /**
@@ -220,7 +220,7 @@ public class CGenerator {
      * @return          a list of one or more statements, fulfilling the preferences
      *                  if preferences cannot be fulfilled, the list is empty
      */
-    public List<String> getNewStatement(StatementPrefs prefs){
+    public List<String> getNewStatements(StatementPrefs prefs){
         // are there any preferences?
         if (prefs==null){
             // there are no preferences, so make an object with only don't-cares
@@ -280,7 +280,7 @@ public class CGenerator {
                         }
 
                         // get statement(s) from feature class
-                        List<String> temp_list = statementGenerator.getNewStatement(p2);
+                        List<String> temp_list = statementGenerator.getNewStatements(p2);
 
                         // the result may be empty, as the feature class may not be able to comply to
                         // the preferences set, in which case the search must continue

--- a/src/main/java/nl/ou/debm/producer/ENumberOfStatementsPref.java
+++ b/src/main/java/nl/ou/debm/producer/ENumberOfStatementsPref.java
@@ -1,5 +1,10 @@
 package nl.ou.debm.producer;
 
+/**
+ * request single or multiple statements
+ */
 public enum ENumberOfStatementsPref {
-    SINGLE, MULTIPLE, DON_T_CARE;
+    SINGLE,             // single statement requested
+    MULTIPLE,           // multiple statements requested
+    DON_T_CARE;         // single or multiple: don't care
 }

--- a/src/main/java/nl/ou/debm/producer/ENumberOfStatementsPref.java
+++ b/src/main/java/nl/ou/debm/producer/ENumberOfStatementsPref.java
@@ -1,0 +1,5 @@
+package nl.ou.debm.producer;
+
+public enum ENumberOfStatementsPref {
+    SINGLE, MULTIPLE, DON_T_CARE;
+}

--- a/src/main/java/nl/ou/debm/producer/EStatementPref.java
+++ b/src/main/java/nl/ou/debm/producer/EStatementPref.java
@@ -1,0 +1,7 @@
+package nl.ou.debm.producer;
+
+public enum EStatementPref {
+    DON_T_CARE,             // whether or not feature is included, doesn't matter
+    REQUIRED,               // this feature is required
+    NOT_WANTED;             // this feature is not wanted
+}

--- a/src/main/java/nl/ou/debm/producer/Function.java
+++ b/src/main/java/nl/ou/debm/producer/Function.java
@@ -106,13 +106,7 @@ public class Function {
     }
 
     /**
-     * see: {@link Function#addStatement(String)}
-     * @param newStatements String list containing new statements
-     */
-    public void addStatement(List<String> newStatements) {statements.addAll(newStatements);};
-
-    /**
-     * see: {@link Function#addStatement(List)}
+     * see: {@link Function#addStatements(List)}
      * @param newStatements String list containing new statements
      */
     public void addStatements(List<String> newStatements) {statements.addAll(newStatements);};

--- a/src/main/java/nl/ou/debm/producer/Function.java
+++ b/src/main/java/nl/ou/debm/producer/Function.java
@@ -93,9 +93,27 @@ public class Function {
         parameters.add(parameter);
     }
 
+    /**
+     * Add single statement to a function.
+     * The caller is responsible for the correct syntax of the statement
+     * added. That means that the caller must terminate the statement with ; when
+     * required by the C standard. It is not forbidden to add multiple statements
+     * in one single string, but it is recommended to use a list as parameter.
+     * @param statement     String representing the statement to be added.
+     */
     public void addStatement(String statement){
         statements.add(statement);
     }
+
+    /**
+     * see: {@link Function#addStatement(String)}
+     * @param newStatements String list containing new statements
+     */
     public void addStatement(List<String> newStatements) {statements.addAll(newStatements);};
+
+    /**
+     * see: {@link Function#addStatement(List)}
+     * @param newStatements String list containing new statements
+     */
     public void addStatements(List<String> newStatements) {statements.addAll(newStatements);};
 }

--- a/src/main/java/nl/ou/debm/producer/Function.java
+++ b/src/main/java/nl/ou/debm/producer/Function.java
@@ -96,4 +96,6 @@ public class Function {
     public void addStatement(String statement){
         statements.add(statement);
     }
+    public void addStatement(List<String> newStatements) {statements.addAll(newStatements);};
+    public void addStatements(List<String> newStatements) {statements.addAll(newStatements);};
 }

--- a/src/main/java/nl/ou/debm/producer/IStatementGenerator.java
+++ b/src/main/java/nl/ou/debm/producer/IStatementGenerator.java
@@ -2,7 +2,24 @@ package nl.ou.debm.producer;
 
 import java.util.List;
 
+
+/**
+ * Interface required for statement implementation
+ */
 public interface IStatementGenerator {
+    /**
+     * Overloaded function, will call getNewStatement(null)
+     * @return  new statement(s)
+     * see: {@link IStatementGenerator#getNewStatement(StatementPrefs)}
+     */
     List<String> getNewStatement();
+
+    /**
+     * Will return one or more statements, according to prefs.
+     * @param prefs set of preferences for statement(s). If set to
+     *              null, all prefs will be set to 'don't care'.
+     * @return  one or more statements. If no statements meeting the
+     *          requirements can be produced, the list is empty
+     */
     List<String> getNewStatement(StatementPrefs prefs);
 }

--- a/src/main/java/nl/ou/debm/producer/IStatementGenerator.java
+++ b/src/main/java/nl/ou/debm/producer/IStatementGenerator.java
@@ -1,5 +1,8 @@
 package nl.ou.debm.producer;
 
+import java.util.List;
+
 public interface IStatementGenerator {
-    String getNewStatement();
+    List<String> getNewStatement();
+    List<String> getNewStatement(StatementPrefs prefs);
 }

--- a/src/main/java/nl/ou/debm/producer/IStatementGenerator.java
+++ b/src/main/java/nl/ou/debm/producer/IStatementGenerator.java
@@ -8,11 +8,11 @@ import java.util.List;
  */
 public interface IStatementGenerator {
     /**
-     * Overloaded function, will call getNewStatement(null)
+     * Overloaded function, will call getNewStatements(null)
      * @return  new statement(s)
-     * see: {@link IStatementGenerator#getNewStatement(StatementPrefs)}
+     * see: {@link IStatementGenerator#getNewStatements(StatementPrefs)}
      */
-    List<String> getNewStatement();
+    List<String> getNewStatements();
 
     /**
      * Will return one or more statements, according to prefs.
@@ -21,5 +21,5 @@ public interface IStatementGenerator {
      * @return  one or more statements. If no statements meeting the
      *          requirements can be produced, the list is empty
      */
-    List<String> getNewStatement(StatementPrefs prefs);
+    List<String> getNewStatements(StatementPrefs prefs);
 }

--- a/src/main/java/nl/ou/debm/producer/StatementPrefs.java
+++ b/src/main/java/nl/ou/debm/producer/StatementPrefs.java
@@ -5,6 +5,9 @@ package nl.ou.debm.producer;
  */
 
 public class StatementPrefs {
+    /**
+     * Default values for empty construction
+     */
     public ENumberOfStatementsPref numberOfStatements = ENumberOfStatementsPref.SINGLE;
     public EStatementPref compoundStatement = EStatementPref.NOT_WANTED;
     public EStatementPref expression = EStatementPref.DON_T_CARE;

--- a/src/main/java/nl/ou/debm/producer/StatementPrefs.java
+++ b/src/main/java/nl/ou/debm/producer/StatementPrefs.java
@@ -1,0 +1,43 @@
+package nl.ou.debm.producer;
+
+/**
+ * This class serves as a struct to easily set preferences for when a statement is requested.
+ */
+
+public class StatementPrefs {
+    public ENumberOfStatementsPref numberOfStatements = ENumberOfStatementsPref.SINGLE;
+    public EStatementPref compoundStatement = EStatementPref.NOT_WANTED;
+    public EStatementPref expression = EStatementPref.DON_T_CARE;
+    public EStatementPref assignment = EStatementPref.DON_T_CARE;
+    public EStatementPref loop = EStatementPref.NOT_WANTED;
+
+    /**
+     * empty constructor, do absolutely nothing but set the defaults as
+     * explained above: <br>
+     * number of statements: 1<br>
+     * compound/loop: not wanted <br>
+     * assignment/expression: don't care
+     */
+    public StatementPrefs(){;}
+
+    /**
+     * This constructor only has a parameter to distinguish from the default
+     * The parameter is not used at all. The constructor makes sure that
+     * the preferences are all set to 'don't care'.
+     * @param o     only used to distinguish between constructors
+     */
+    public StatementPrefs(Object o){
+        SetDonTCare();
+    }
+
+    /**
+     * Set all preferences to 'don't care'.
+     */
+    public void SetDonTCare(){
+        numberOfStatements = ENumberOfStatementsPref.DON_T_CARE;
+        compoundStatement = EStatementPref.DON_T_CARE;
+        expression = EStatementPref.DON_T_CARE;
+        assignment = EStatementPref.DON_T_CARE;
+        loop = EStatementPref.DON_T_CARE;
+    }
+}


### PR DESCRIPTION
This branch introduces multiple statement creation and statement preferences.

*Statement creation*
In stead of only a single string, statement producers produce a list of strings. In certain circumstances (see below) the list may be empty.

*Statement prefs*
Any class asking the c-generator for a statement or statements, can pass preferences as to the result, for example, a loop may be requested. Or anything but a loop. Or a compound, or anything but a compound. Or: anything at all (all prefs set to 'don't care')