### PR TITLE
CodeMarker additions and global labels

### DIFF
--- a/src/main/java/nl/ou/debm/common/CodeMarker.java
+++ b/src/main/java/nl/ou/debm/common/CodeMarker.java
@@ -27,6 +27,7 @@ public class CodeMarker {
     private static final char DOUBLEQUOTES ='\"';           // escape necessary to use the toSting-result as a string in C-code
     private static final char ESCAPECHAR ='\\';             // escapes special separator chars
     private static final char[] ESCAPESEQUENCE = {ESCAPECHAR, PROPERTYSEPARATOR, VALUESEPARATOR, DOUBLEQUOTES};
+    private static final String STRDECIMALFIELD = "__DECIMAL_FIELD__";  // special field to be used with printf
 
     // the actual map, containing all the data
     private final HashMap<String, String> propMap = new HashMap<>();
@@ -95,6 +96,15 @@ public class CodeMarker {
     private void setID(){
         long id = lngNextCodeMarkerID++;
         propMap.put(STRIDFIELD, Long.toHexString(id));
+    }
+
+    /**
+     * Make sure a property is added with "%d" as value. When it comes
+     * to making a marker, this part of the string can be used by printf
+     * to print a decimal variable
+     */
+    public void AddDecimalField(){
+        setProperty(STRDECIMALFIELD, "%d");
     }
 
     /**
@@ -231,5 +241,19 @@ public class CodeMarker {
             strIn = strIn.replace( "" + ESCAPECHAR + p, "" + ESCAPESEQUENCE[p]);
         }
         return strIn;
+    }
+
+    /**
+     * Return a complete codemarker statement, which comes down to: printf([codeMarker_in_double_quotes]);
+     * @return  the appropriate printf-statement
+     */
+    public String strPrintf(){
+        return "printf(\"" + toString() + "\");";
+    }
+
+    public String strPrintfDecimal(String strVariableName){
+        // make sure a decimal field is added
+        AddDecimalField();
+        return "printf(\"" + toString() + "\", " + strVariableName + ");";
     }
 }

--- a/src/main/java/nl/ou/debm/producer/CGenerator.java
+++ b/src/main/java/nl/ou/debm/producer/CGenerator.java
@@ -34,6 +34,8 @@ public class CGenerator {
     public List<Struct> structs = new ArrayList<>();            // store structs
     public final DataType[] rawDataTypes = new DataType[6];     // table of basic data types
     private Function mainFunction;                              // main function
+    private long lngNextGlobalLabel = 0;                        // index for next requested global label name
+
 
     public CGenerator() {
         // constructor
@@ -505,5 +507,17 @@ public class CGenerator {
             }
             return globalsByType.get(type).get(ThreadLocalRandom.current().nextInt(0, globalsByType.get(type).size()));
         }
+    }
+
+    /**
+     * Get a label that is globally unique.
+     * @return  "_LAB*;", where * is a unique sequential number (long type)
+     */
+    public String getLabel(){
+        /*
+         Labels in C have a function scope, but as it is not easy to determine
+         in which function code is added, we use globally unique labels.
+         */
+        return "_LAB" + lngNextGlobalLabel++ + ":";
     }
 }

--- a/src/main/java/nl/ou/debm/test/CodeMarkerTest.java
+++ b/src/main/java/nl/ou/debm/test/CodeMarkerTest.java
@@ -200,6 +200,70 @@ public class CodeMarkerTest {
         }
     }
 
+    @Test
+    void TestPrintf(){
+        CodeMarker cm = new CodeMarker();
+        final String STRVARNAME="sunshine";
+
+        cm.setProperty("Name","Harry");
+        cm.setProperty("BookTitle", "\"Harry Potter and the Prisoner of Azkaban\"");
+
+        for (int t=0;t<2;++t) {
+
+            // 0 = test printf
+            // 1 = test printf + numberic variable
+
+            String statement;
+            if (t==0){
+                statement =cm.strPrintf();
+            }
+            else {
+                statement = cm.strPrintfDecimal(STRVARNAME);
+            }
+            System.out.println(statement);
+
+            // make sure the wrap is ok
+            assertEquals(0, statement.indexOf("printf("));                      // starts with printf(
+            assertEquals(statement.length() - 2, statement.indexOf(");"));      // ends with );
+            // check quotes
+            int lp=0;
+            for (int q=0; q<3; q++){
+                // look for a quote
+                int np = statement.indexOf("\"",lp);
+                if (q==0){
+                    // first quote must be directly after 'printf('
+                    assertEquals(7, np);
+                }
+                else if (q==1){
+                    // there must be a second quote
+                    assertNotEquals(-1,np);
+                }
+                else {
+                    // there may not be a third quote
+                    assertEquals(-1, np);
+                }
+
+                // next quote
+                lp = np + 1;
+            }
+
+            if (t==0){
+                assertEquals(statement.length() - 3, statement.indexOf("\");"));      // ends with ");
+            }
+            else {
+                // var name found after quotes?
+                int p2 = statement.indexOf("\"",8);
+                int p3 = statement.indexOf(STRVARNAME, p2);
+                assertNotEquals(-1, p3);
+                // , before varname?
+                int p4= statement.indexOf(",", p2);
+                assertNotEquals(-1,p4);
+                assertTrue(p4<p3);
+            }
+        }
+
+    }
+
     void CheckUnique (CodeMarker[] cm){
         // make sure all ID's are unique
         int x, y;


### PR DESCRIPTION
This pull request adds functionality to codemarkers and introduces globally unique labels in CGenerator.
A CodeMarker Object will return a string as usual when toString is used, but as this string will frequently be used in printf-calls, two functions are added:
strPrintf -- will return a correct printf-call (including the quoted CodeMarker-toString output and a trailing semi-colon)
strPrintfDecimal -- will make sure that a numberic field is inserted in the CodeMarker, so that "%d" will be included in the string, and it will make printf("codemarkertextincludinga%d", variablename);.
A call to CGenerator.strGetLabel will return something like: "_LAB1234:"