### PR TITLE
getNewStatements gets passed function object

### DIFF
--- a/src/main/java/nl/ou/debm/common/feature1/ControlFlowFeature.java
+++ b/src/main/java/nl/ou/debm/common/feature1/ControlFlowFeature.java
@@ -59,12 +59,12 @@ public class ControlFlowFeature implements  IFeature, IAssessor, IStatementGener
     }
 
     @Override
-    public List<String> getNewStatements() {
-        return getNewStatements(null);
+    public List<String> getNewStatements(Function f) {
+        return getNewStatements(f, null);
     }
 
     @Override
-    public List<String> getNewStatements(StatementPrefs prefs) {
+    public List<String> getNewStatements(Function f, StatementPrefs prefs) {
         // check prefs object
         if (prefs == null){
             prefs = new StatementPrefs(null);

--- a/src/main/java/nl/ou/debm/common/feature2/DataStructuresFeature.java
+++ b/src/main/java/nl/ou/debm/common/feature2/DataStructuresFeature.java
@@ -18,12 +18,12 @@ public class DataStructuresFeature implements IFeature, IStatementGenerator, ISt
     }
 
     @Override
-    public List<String> getNewStatements() {
-        return getNewStatements(null);
+    public List<String> getNewStatements(Function f) {
+        return getNewStatements(f, null);
     }
 
     @Override
-    public List<String> getNewStatements(StatementPrefs prefs) {
+    public List<String> getNewStatements(Function f, StatementPrefs prefs) {
         // check preferences object
         if (prefs==null){
             prefs = new StatementPrefs(null);

--- a/src/main/java/nl/ou/debm/common/feature3/FunctionProducer.java
+++ b/src/main/java/nl/ou/debm/common/feature3/FunctionProducer.java
@@ -95,9 +95,9 @@ public class FunctionProducer implements IFeature, IExpressionGenerator, IFuncti
 
         // add three statements
         // prefer exactly one statement per call
-        function.addStatements(generator.getNewStatements());
-        function.addStatements(generator.getNewStatements());
-        function.addStatements(generator.getNewStatements());
+        function.addStatements(generator.getNewStatements(function));
+        function.addStatements(generator.getNewStatements(function));
+        function.addStatements(generator.getNewStatements(function));
 
         if(tailCallCount < 2){
             tailCallCount++;

--- a/src/main/java/nl/ou/debm/producer/CGenerator.java
+++ b/src/main/java/nl/ou/debm/producer/CGenerator.java
@@ -124,7 +124,7 @@ public class CGenerator {
         // the main function may, in the end, turn out to be very short:
         // it may even have only one line!
         while (!allFeaturesSatisfied()) {
-            mainFunction.addStatements(getNewStatements());
+            mainFunction.addStatements(getNewStatements(mainFunction));
         }
 
         // Use standard exit code as a last statement
@@ -210,8 +210,8 @@ public class CGenerator {
      * an expression (see: getNewExpression).
      * @return   list of Strings containing one or more statements
      */
-    public List<String> getNewStatements() {
-        return getNewStatements(null);
+    public List<String> getNewStatements(Function f) {
+        return getNewStatements(f, null);
     }
 
     /**
@@ -222,7 +222,7 @@ public class CGenerator {
      * @return          a list of one or more statements, fulfilling the preferences
      *                  if preferences cannot be fulfilled, the list is empty
      */
-    public List<String> getNewStatements(StatementPrefs prefs){
+    public List<String> getNewStatements(Function f, StatementPrefs prefs){
         // are there any preferences?
         if (prefs==null){
             // there are no preferences, so make an object with only don't-cares
@@ -282,7 +282,7 @@ public class CGenerator {
                         }
 
                         // get statement(s) from feature class
-                        List<String> temp_list = statementGenerator.getNewStatements(p2);
+                        List<String> temp_list = statementGenerator.getNewStatements(f, p2);
 
                         // the result may be empty, as the feature class may not be able to comply to
                         // the preferences set, in which case the search must continue

--- a/src/main/java/nl/ou/debm/producer/DataType.java
+++ b/src/main/java/nl/ou/debm/producer/DataType.java
@@ -1,11 +1,25 @@
 package nl.ou.debm.producer;
 
+/*
+    Data type class, is used to store datatypes
+ */
+
 public class DataType {
+    // data type name (such as "char", "int" or "SThisIsAStruct"
     protected String name;
+
+    /**
+     * default constructor, takes a data type name as parameter
+     * @param name  name of the datatype, such as "int", "CThisIsAClass" or "ptr*"
+     */
     public DataType(String name){
         this.name = name;
     }
 
+    /**
+     * returns the name of the datatype
+     * @return  name of datatype, such as "int", "CThisIsAClass" or "ptr*"
+     */
     public String getName(){
         return name;
     }
@@ -14,32 +28,94 @@ public class DataType {
         return name;
     }
 
+    /**
+     * set prefix for datatype
+     * @param prefix  such as "JBC", "Reijer", "Dinky". An underscore is automatically added
+     */
     public void prefixName(String prefix){
         name = prefix + "_" + name;
     }
 
+    /**
+     * determine whether datatype is "char"
+     * @return  true when datatype is char
+     */
     public boolean bIsChar(){
         return name.equals("char");
     }
+    /**
+     * determine whether datatype is "int"
+     * @return  true when datatype is int
+     */
     public boolean bIsInt(){
         return name.equals("int");
     }
+    /**
+     * determine whether datatype is "float"
+     * @return  true when datatype is float
+     */
     public boolean bIsFloat(){
         return name.equals("float");
     }
+    /**
+     * determine whether datatype is "double"
+     * @return  true when datatype is double
+     */
     public boolean bIsDouble(){
         return name.equals("double");
     }
+    /**
+     * determine whether datatype is "short"
+     * @return  true when datatype is short int/short
+     */
     public boolean bIsShortInt(){
-        return name.equals("short");
+        return (name.equals("short") || name.equals("short int"));
     }
+    /**
+     * determine whether datatype is "long"
+     * @return  true when datatype is long
+     */
     public boolean bIsLongInt(){
         return name.equals("long");
     }
+    /**
+     * determine whether datatype is any of the primitives
+     * @return  true when datatype is any of the primitives
+     */
     public boolean bIsPrimitive(){
         return bIsChar() || bIsDouble() || bIsFloat() || bIsInt() || bIsShortInt() || bIsLongInt();
     }
-    public boolean bIsNumberic(){
+    /**
+     * determine whether datatype is a numeric datatype (primitives -/- char)
+     * @return  true when datatype is numeric (primitive -/- char)
+     */
+    public boolean bIsNumeric(){
         return bIsPrimitive() && !bIsChar();
+    }
+    public boolean bIsNonFixedNumeric(){
+        return bIsDouble() || bIsFloat();
+    }
+
+    /**
+     * Get a default value for this datatype. Highly usable when writing return statements, so
+     * they can match a function's type
+     * @return  default value as a string, for example "0", "\"a\"", "0.0", "NULL"<br>
+     *          any primitive will return some value, any non-primitive will return NULL,
+     *          a void will return an empty string ("")
+     */
+    public String strDefaultValue(){
+        if (bIsChar()){
+            return "\"a\"";
+        }
+        if (bIsNonFixedNumeric()){
+            return "0.0";
+        }
+        if (bIsPrimitive()){
+            return "0";
+        }
+        if (name.equals("void")){
+            return "";
+        }
+        return "NULL";
     }
 }

--- a/src/main/java/nl/ou/debm/producer/DataType.java
+++ b/src/main/java/nl/ou/debm/producer/DataType.java
@@ -99,13 +99,13 @@ public class DataType {
     /**
      * Get a default value for this datatype. Highly usable when writing return statements, so
      * they can match a function's type
-     * @return  default value as a string, for example "0", "\"a\"", "0.0", "NULL"<br>
+     * @return  default value as a string, for example "0", "'a'", "0.0", "NULL"<br>
      *          any primitive will return some value, any non-primitive will return NULL,
      *          a void will return an empty string ("")
      */
     public String strDefaultValue(){
         if (bIsChar()){
-            return "\"a\"";
+            return "'a'";
         }
         if (bIsNonFixedNumeric()){
             return "0.0";

--- a/src/main/java/nl/ou/debm/producer/Function.java
+++ b/src/main/java/nl/ou/debm/producer/Function.java
@@ -107,5 +107,5 @@ public class Function {
      * see: {@link Function#addStatements(List)}
      * @param newStatements String list containing new statements
      */
-    public void addStatements(List<String> newStatements) {statements.addAll(newStatements);};
+    public void addStatements(List<String> newStatements) {statements.addAll(newStatements);}
 }

--- a/src/main/java/nl/ou/debm/producer/IStatementGenerator.java
+++ b/src/main/java/nl/ou/debm/producer/IStatementGenerator.java
@@ -9,17 +9,19 @@ import java.util.List;
 public interface IStatementGenerator {
     /**
      * Overloaded function, will call getNewStatements(null)
+     * @param f function in whose body the statement will be put
      * @return  new statement(s)
-     * see: {@link IStatementGenerator#getNewStatements(StatementPrefs)}
+     * see: {@link IStatementGenerator#getNewStatements(Function, StatementPrefs)}
      */
-    List<String> getNewStatements();
+    List<String> getNewStatements(Function f);
 
     /**
      * Will return one or more statements, according to prefs.
      * @param prefs set of preferences for statement(s). If set to
      *              null, all prefs will be set to 'don't care'.
+     * @param f function in whose body the statement will be put
      * @return  one or more statements. If no statements meeting the
      *          requirements can be produced, the list is empty
      */
-    List<String> getNewStatements(StatementPrefs prefs);
+    List<String> getNewStatements(Function f, StatementPrefs prefs);
 }


### PR DESCRIPTION
A statement producer needs to know which function it is in. If it doesn't, it cannot use the functions parameters, nor could it use return statements, as it doesn't know what to return.
This pull request changes the IStatementGenerator slightly and modifies code that implement it.
It also modifies DataType, so it return a default value. This is highly useable when writing return statements, as the return type is passed in the function object and the DataType-class will put it in ascii.