### PR TITLE
Environment and CompilerConfig classes

### DIFF
--- a/src/main/java/nl/ou/debm/assessor/Assessor.java
+++ b/src/main/java/nl/ou/debm/assessor/Assessor.java
@@ -34,7 +34,7 @@ public class Assessor {
 
     public void RunTheTests(final String strContainersBaseFolder, final String strDecompileScript) throws Exception {
         // set root path, to be used program-wide (as it is a static)
-        IOElements.setBasePath(strContainersBaseFolder);
+        Environment.containerBasePath = strContainersBaseFolder;
 
         // get name of the decompiler-script and test its existence & executableness
         if (!Files.isExecutable(Paths.get(strDecompileScript))) {

--- a/src/main/java/nl/ou/debm/assessor/Main.java
+++ b/src/main/java/nl/ou/debm/assessor/Main.java
@@ -1,8 +1,8 @@
 package nl.ou.debm.assessor;
 
-import java.security.InvalidParameterException;
+import nl.ou.debm.common.Environment;
 
-import static nl.ou.debm.common.Misc.strGetContainersBaseFolder;
+import java.security.InvalidParameterException;
 
 public class Main {
 
@@ -11,7 +11,7 @@ public class Main {
             throw new InvalidParameterException("Program can only be run with exactly one argument!");
 
         var ass = new Assessor();
-        ass.RunTheTests(strGetContainersBaseFolder(),
+        ass.RunTheTests(Environment.containerBasePath,
                 args[0]);
     }
 }

--- a/src/main/java/nl/ou/debm/common/CompilerConfig.java
+++ b/src/main/java/nl/ou/debm/common/CompilerConfig.java
@@ -2,7 +2,6 @@ package nl.ou.debm.common;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 public class CompilerConfig {
     public ECompiler compiler;
@@ -68,7 +67,7 @@ public class CompilerConfig {
             config.optimization = optimization;
 
             //determine path based on the environment
-            if (Environment.actual == Environment.EnvEnum.KESAVA) {
+            if (Environment.actual == Environment.EEnv.KESAVA) {
                 //use a different path for the 32-bit compiler
                 if (arch == EArchitecture.X86ARCH && compiler == ECompiler.CLANG) {
                     config.path = "C:\\winlibs-i686-posix-dwarf-gcc-13.2.0-llvm-17.0.6-mingw-w64msvcrt-11.0.1-r3\\mingw32\\bin\\clang.exe";

--- a/src/main/java/nl/ou/debm/common/CompilerConfig.java
+++ b/src/main/java/nl/ou/debm/common/CompilerConfig.java
@@ -1,0 +1,80 @@
+package nl.ou.debm.common;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class CompilerConfig {
+    public ECompiler compiler;
+    public EArchitecture arch;
+    public EOptimize optimization;
+    private String path = "";
+
+    public String getPath() throws Exception {
+        if (path == "") {
+            path = Misc.strGetExternalSoftwareLocation(compiler.strProgramName());
+        }
+        return path;
+    }
+
+    public List<String> compileCommandParameters(
+            String sourceFilePath,
+            String targetFilePath,
+            boolean generate_LLVM_IR
+    ) throws Exception {
+        List<String> ret = new ArrayList<>();
+
+        if (compiler == ECompiler.CLANG) {
+            ret.add(getPath());
+            ret.add(sourceFilePath);
+            ret.add("-o"); ret.add(targetFilePath);
+
+            if (optimization == EOptimize.OPTIMIZE)
+                ret.add("-O3");
+            else
+                ret.add("-O0"); //this is also the default
+
+            switch (arch) {
+                case X64ARCH -> {
+                    ret.add("-march=x86-64");
+                    ret.add("-m64");
+                }
+                case X86ARCH -> {
+                    ret.add("-march=i686");
+                    ret.add("-m32");
+                }
+            }
+
+            if (generate_LLVM_IR) {
+                ret.add("-S");
+                ret.add("-emit-llvm");
+            }
+        }
+
+        return ret;
+    }
+
+    public static final List<CompilerConfig> configs;
+    static {
+        configs = new ArrayList<>();
+
+        for (var compiler : ECompiler.values())
+        for (var arch : EArchitecture.values())
+        for (var optimization : EOptimize.values())
+        {
+            var config = new CompilerConfig();
+            config.compiler = compiler;
+            config.arch = arch;
+            config.optimization = optimization;
+
+            //determine path based on the environment
+            if (Environment.actual == Environment.EnvEnum.KESAVA) {
+                //use a different path for the 32-bit compiler
+                if (arch == EArchitecture.X86ARCH && compiler == ECompiler.CLANG) {
+                    config.path = "C:\\winlibs-i686-posix-dwarf-gcc-13.2.0-llvm-17.0.6-mingw-w64msvcrt-11.0.1-r3\\mingw32\\bin\\clang.exe";
+                }
+            }
+            configs.add(config);
+        }
+    }
+}

--- a/src/main/java/nl/ou/debm/common/ECompiler.java
+++ b/src/main/java/nl/ou/debm/common/ECompiler.java
@@ -1,45 +1,28 @@
 package nl.ou.debm.common;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public enum ECompiler {
     CLANG {
-        private String strCompilerLocation = "";
         public String strFileCode()             { return "cln"; }
-        public String strCommand()              { return "clang"; }
-        public String strCommandLocation() throws Exception {
-            if (strCompilerLocation.isEmpty()){
-                strCompilerLocation = Misc.strGetExternalSoftwareLocation(strCommand());
-            }
-            return strCompilerLocation;
-        }
-        public String strOutputSwitch()         { return "-o";}
-        public String strArchitectureFlag(EArchitecture architecture){
-            return switch (architecture){
-                case X64ARCH -> "-march=x86-64";
-                case X86ARCH -> "-march=native";
-            };
-        }
-        public String strOptFlag(EOptimize optimize){
-            return switch (optimize){
-                case OPTIMIZE -> "-O3";
-                case NO_OPTIMIZE -> "-O0";
-            };
-        }
+        public String strProgramName()              { return "clang"; }
     }/*,
     GCC {
         public String strFileCode() { return "gcc"; }
-        public String strCommand() { return "gcc"; }
+        public String strProgramName() { return "gcc"; }
     }*/;
 
     public String strFileCode(){
         return "";
     }
-    public String strCommand(){
+    public String strProgramName(){
         return "";
     }
     public String strCommandLocation() throws Exception {
         return "";
     }
-
+    //todo waar is dit voor? alleen strFileCod en strProgramName worden nog gebruikt.
     public String strArchitectureFlag(EArchitecture architecture){
         return "";
     }

--- a/src/main/java/nl/ou/debm/common/Environment.java
+++ b/src/main/java/nl/ou/debm/common/Environment.java
@@ -5,10 +5,10 @@ package nl.ou.debm.common;
 */
 
 public class Environment {
-    public static EnvEnum actual;
+    public static EEnv actual;
     public static String containerBasePath;
 
-    public enum EnvEnum {
+    public enum EEnv {
         KESAVA,
         JAAP,
         REIJER,
@@ -16,11 +16,11 @@ public class Environment {
     }
 
     static {
-        actual = EnvEnum.DEFAULT;
+        actual = EEnv.DEFAULT;
 
-        if (IOElements.bFolderExists("C:\\OU\\IB9902, IB9906 - Afstudeerproject\\")) { actual = EnvEnum.KESAVA; }
-        if (IOElements.bFolderExists("C:\\Users\\reije\\")) { actual = EnvEnum.REIJER; }
-        if (IOElements.bFolderExists("/home/jaap/VAF")) { actual = EnvEnum.JAAP; }
+        if (IOElements.bFolderExists("C:\\OU\\IB9902, IB9906 - Afstudeerproject\\")) { actual = EEnv.KESAVA; }
+        if (IOElements.bFolderExists("C:\\Users\\reije\\")) { actual = EEnv.REIJER; }
+        if (IOElements.bFolderExists("/home/jaap/VAF")) { actual = EEnv.JAAP; }
 
         //set containerBaseFolder
         containerBasePath = switch (actual) {

--- a/src/main/java/nl/ou/debm/common/Environment.java
+++ b/src/main/java/nl/ou/debm/common/Environment.java
@@ -8,7 +8,7 @@ public class Environment {
     public static EnvEnum actual;
     public static String containerBasePath;
 
-    enum EnvEnum {
+    public enum EnvEnum {
         KESAVA,
         JAAP,
         REIJER,
@@ -18,10 +18,9 @@ public class Environment {
     static {
         actual = EnvEnum.DEFAULT;
 
-        //Uncomment any of the following to enable the environment.
-        //actual = env_code.JAAP;
-        actual = EnvEnum.KESAVA;
-        //actual = env_code.REIJER;
+        if (IOElements.bFolderExists("C:\\OU\\IB9902, IB9906 - Afstudeerproject\\")) { actual = EnvEnum.KESAVA; }
+        if (IOElements.bFolderExists("C:\\Users\\reije\\")) { actual = EnvEnum.REIJER; }
+        if (IOElements.bFolderExists("/home/jaap/VAF")) { actual = EnvEnum.JAAP; }
 
         //set containerBaseFolder
         containerBasePath = switch (actual) {
@@ -30,5 +29,8 @@ public class Environment {
             case REIJER -> "C:\\Users\\reije\\OneDrive\\Documenten\\Development\\c-program\\containers\\";
             case DEFAULT -> "containers";
         };
+
+        System.out.println("using environment " + actual.toString());
+        System.out.println("using containerBasePath " + containerBasePath);
     }
 }

--- a/src/main/java/nl/ou/debm/common/Environment.java
+++ b/src/main/java/nl/ou/debm/common/Environment.java
@@ -1,0 +1,34 @@
+package nl.ou.debm.common;
+
+/*
+    This class stores a global indicator of the environment. The assumption is that this indicator is set at program startup and remains the same throughout the program execution. The indicator is used here and elsewhere in the code for environment dependent behavior.
+*/
+
+public class Environment {
+    public static EnvEnum actual;
+    public static String containerBasePath;
+
+    enum EnvEnum {
+        KESAVA,
+        JAAP,
+        REIJER,
+        DEFAULT
+    }
+
+    static {
+        actual = EnvEnum.DEFAULT;
+
+        //Uncomment any of the following to enable the environment.
+        //actual = env_code.JAAP;
+        actual = EnvEnum.KESAVA;
+        //actual = env_code.REIJER;
+
+        //set containerBaseFolder
+        containerBasePath = switch (actual) {
+            case KESAVA -> "C:\\OU\\IB9902, IB9906 - Afstudeerproject\\_repo\\decompiler-benchmarking\\containers\\";
+            case JAAP -> "/home/jaap/VAF/containers/";
+            case REIJER -> "C:\\Users\\reije\\OneDrive\\Documenten\\Development\\c-program\\containers\\";
+            case DEFAULT -> "containers";
+        };
+    }
+}

--- a/src/main/java/nl/ou/debm/common/IOElements.java
+++ b/src/main/java/nl/ou/debm/common/IOElements.java
@@ -1,7 +1,9 @@
 package nl.ou.debm.common;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 
@@ -27,15 +29,6 @@ public class IOElements {
     private static final String testFolderPrefix = "test_";
     private static final int numberOfDigits = 3;
 
-
-    private static String m_strBasePath="";
-
-    public static void setBasePath(String strBasePath){
-        m_strBasePath = strAdaptPathToMatchFileSystemAndAddSeparator(strBasePath);
-    }
-    public static String getBasePath(){
-        return m_strBasePath;
-    }
 
     /**
      * Convert the path separators in a string to the OS-specific separators.
@@ -76,21 +69,21 @@ public class IOElements {
 
 
     public static String strBinaryFullFileName(int iContainer, int iTest, EArchitecture architecture, ECompiler compiler, EOptimize optimize){
-        return strBinaryFullFileName(m_strBasePath, iContainer, iTest, architecture, compiler, optimize);
+        return strBinaryFullFileName(Environment.containerBasePath, iContainer, iTest, architecture, compiler, optimize);
     }
     public static String strBinaryFullFileName(String strBasePath, int iContainer, int iTest, EArchitecture architecture, ECompiler compiler, EOptimize optimize){
         return strTestFullPath(strBasePath, iContainer, iTest) +
                 strCombineName(binaryPrefix, architecture, compiler, optimize, binaryPostfix);
     }
     public static String strLLVMFullFileName(int iContainer, int iTest, EArchitecture architecture, ECompiler compiler, EOptimize optimize){
-        return strLLVMFullFileName(m_strBasePath, iContainer, iTest, architecture, compiler, optimize);
+        return strLLVMFullFileName(Environment.containerBasePath, iContainer, iTest, architecture, compiler, optimize);
     }
     public static String strLLVMFullFileName(String strBasePath, int iContainer, int iTest, EArchitecture architecture, ECompiler compiler, EOptimize optimize){
         return strTestFullPath(strBasePath, iContainer, iTest) +
                 strCombineName(llvmPrefix, architecture, compiler, optimize, llvmPostfix);
     }
     public static String strCSourceFullFilename(int iContainer, int iTest){
-        return strCSourceFullFilename(m_strBasePath, iContainer, iTest);
+        return strCSourceFullFilename(Environment.containerBasePath, iContainer, iTest);
     }
     public static String strCSourceFullFilename(String strBasePath, int iContainer, int iTest){
         return strTestFullPath(strBasePath, iContainer, iTest) + cSourceName;
@@ -103,14 +96,14 @@ public class IOElements {
                 strPostfix;
     }
     public static String strContainerFullPath(int iContainer){
-        return strContainerFullPath(m_strBasePath, iContainer);
+        return strContainerFullPath(Environment.containerBasePath, iContainer);
     }
     public static String strContainerFullPath(String strBasePath, int iContainer){
         return strAdaptPathToMatchFileSystemAndAddSeparator(strBasePath) +
                 containerFolderPrefix + strGetNumberWithPrefixZeros(iContainer, numberOfDigits) + File.separatorChar;
     }
     public static String strTestFullPath(int iContainer, int iTest){
-        return strTestFullPath(m_strBasePath, iContainer, iTest);
+        return strTestFullPath(Environment.containerBasePath, iContainer, iTest);
     }
     public static String strTestFullPath(String strBasePath, int iContainer, int iTest){
         return strContainerFullPath(strBasePath, iContainer) +
@@ -143,6 +136,13 @@ public class IOElements {
         }
         catch (IOException ignored){
         }
+    }
+
+    public static void writeToFile(String s, String path) throws IOException {
+        var writer = new OutputStreamWriter(new FileOutputStream(path));
+        writer.write(s);
+        writer.flush();
+        writer.close();
     }
 
     /**

--- a/src/main/java/nl/ou/debm/common/Misc.java
+++ b/src/main/java/nl/ou/debm/common/Misc.java
@@ -1,9 +1,7 @@
 package nl.ou.debm.common;
 
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.util.Random;
 
 import static java.lang.Math.abs;
@@ -45,24 +43,6 @@ public class Misc {
         }
         // return the proper result
         return strTmp.substring(strTmp.length()-iLength);
-    }
-
-    /**
-     * Get the base-folder for the containers, based on Linux-arch (Jaaps PC) or
-     * Windows-arch (Reijers PC/Kesava's PC)
-     * @return  base folder for containers
-     * TODO: implement Kesava's PC
-     */
-    public static String strGetContainersBaseFolder(){
-        // TODO: Find a nicer debug-solution
-
-        if (File.separatorChar == '/'){
-            // assume: Jaap
-            return "/home/jaap/VAF/containers/";
-        }
-        else{
-            return "C:\\Users\\reije\\OneDrive\\Documenten\\Development\\c-program\\containers\\";
-        }
     }
 
     private static boolean bRunsOnWindows(){

--- a/src/main/java/nl/ou/debm/producer/CGenerator.java
+++ b/src/main/java/nl/ou/debm/producer/CGenerator.java
@@ -47,6 +47,7 @@ public class CGenerator {
         features.add(new LoopProducer(this));
 
         // fill array of raw data types
+        //todo hier meer bij? er bestaan ook types int64_t, uint32_t etc. zie https://en.wikibooks.org/wiki/C_Programming/stdint.h
         rawDataTypes[0] = new DataType("short");
         rawDataTypes[1] = new DataType("int");
         rawDataTypes[2] = new DataType("long");
@@ -198,7 +199,7 @@ public class CGenerator {
      * Return index to the current feature to be used and then switch to the next feature
      * @return  feature-index, ranging 0... features.size()
      */
-    private int iNextFeatureIndex () {
+    private int iNextFeatureIndex() {
         int q = featureIndex;
         featureIndex++;
         featureIndex%=features.size();
@@ -222,9 +223,9 @@ public class CGenerator {
      * @return          a list of one or more statements, fulfilling the preferences
      *                  if preferences cannot be fulfilled, the list is empty
      */
-    public List<String> getNewStatements(Function f, StatementPrefs prefs){
+    public List<String> getNewStatements(Function f, StatementPrefs prefs) {
         // are there any preferences?
-        if (prefs==null){
+        if (prefs==null) {
             // there are no preferences, so make an object with only don't-cares
             prefs = new StatementPrefs(null);
         }
@@ -323,7 +324,7 @@ public class CGenerator {
      * @param path   Full path and file name of the output file
      * @throws Exception
      */
-    public void generateSourceFile(String path) throws IOException, Exception {
+    public String generateSourceFile() throws Exception {
         //Check prefixes are unique
         // TODO: this part should be refactored to test code, which should test the /
         //  uniqueness of the names & abbrevs in EFeaturePrefix /
@@ -355,11 +356,15 @@ public class CGenerator {
         writeStructs();
         // continue with globals, as they may use data structures
         writeGlobalVariables();
-        // end with all the functions, as they may both use globlas and data structures
+        // end with all the functions, as they may both use globals and data structures //todo ware het niet dat globale variabelen ook functies kunnen gebruiken. Leidt dat tot een probleem? Vast niet, maar dan doen we hier dus de aanname dat globale variabelen niet met een functieaanroep worden geïnitialiseerd.
         writeFunctions();
-        // export the lot to the designated file
+        return sb.toString();
+    }
+
+    public void generateSourceFile(String path) throws IOException, Exception {
+        String content = generateSourceFile();
         var writer = new OutputStreamWriter(new FileOutputStream(path));
-        writer.write(sb.toString());
+        writer.write(content);
         writer.flush();
         writer.close();
     }

--- a/src/main/java/nl/ou/debm/producer/Main.java
+++ b/src/main/java/nl/ou/debm/producer/Main.java
@@ -39,9 +39,11 @@ public class Main {
 
                 var sourceFilePath = IOElements.strCSourceFullFilename(containerIndex, testIndex);
 
+
                 System.out.print("generating C source file");
                 String program = new CGenerator().generateSourceFile();
                 System.out.println(" done");
+
                 System.out.print("writing C source file");
                 IOElements.writeToFile(program, sourceFilePath);
                 System.out.println(" done");
@@ -98,6 +100,7 @@ public class Main {
                 System.out.print("compiling ");
                 var results = EXEC.invokeAll(tasks);
                 System.out.println(" done");
+                //todo after this the compilation processes have all ended, yet the program still hangs for ~1 minute
             }
         }
     }

--- a/src/main/java/nl/ou/debm/producer/Main.java
+++ b/src/main/java/nl/ou/debm/producer/Main.java
@@ -6,6 +6,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 
@@ -16,9 +17,7 @@ public class Main {
         final var amountOfSources = 1;
 
         //1. Initialize folder structure
-        // set base path for all container operations, use a hack to differentiate between Reijer & Jaap & Kesava
-        IOElements.setBasePath(Misc.strGetContainersBaseFolder());
-        var containersFolder = new File(IOElements.getBasePath());
+        var containersFolder = new File(Environment.containerBasePath);
         if (!containersFolder.exists() && !containersFolder.mkdirs())
             throw new Exception("Unable to create containers folder");
 
@@ -30,7 +29,7 @@ public class Main {
                 throw new Exception("Unable to create package folder" + containerIndex);
 
             //3. Generate C-sources
-            var EXEC = Executors.newCachedThreadPool();
+            var EXEC = Executors.newCachedThreadPool(); //todo leidt tot problemen als er heel veel taken zijn. Zie https://www.baeldung.com/java-executors-cached-fixed-threadpool "The cached pool starts with zero threads and can potentially grow to have Integer.MAX_VALUE threads". Alternatief: newFixedThreadPool(n), alleen je moet dan zelf opgeven hoe veel threads (n) hij maximaal mag aanmaken, bijv. het aantal cpus in de computer (hoe krijg je dat aantal te pakken in java?)
             var tasks = new ArrayList<Callable<String>>();
             for (var testIndex = 0; testIndex < amountOfSources; testIndex++) {
                 var testFolderPath = IOElements.strTestFullPath(containerIndex, testIndex);
@@ -39,59 +38,67 @@ public class Main {
                     throw new Exception("Unable to create test folder" + testIndex);
 
                 var sourceFilePath = IOElements.strCSourceFullFilename(containerIndex, testIndex);
-                new CGenerator().generateSourceFile(sourceFilePath);
+
+                System.out.print("generating C source file");
+                String program = new CGenerator().generateSourceFile();
+                System.out.println(" done");
+                System.out.print("writing C source file");
+                IOElements.writeToFile(program, sourceFilePath);
+                System.out.println(" done");
 
                 //4. call compiler(s)
-                for (var compiler : ECompiler.values()) {
-                    var cLangLocation = compiler.strCommandLocation();
-                    for (var architecture : EArchitecture.values()) {
-                        for (var optimize : EOptimize.values()) {
-                            var binaryPath = IOElements.strBinaryFullFileName(containerIndex, testIndex, architecture, compiler, optimize);
-                            var llvmPath = IOElements.strLLVMFullFileName(containerIndex, testIndex, architecture, compiler, optimize);
-                            //Generate binary
-                            tasks.add(() -> {
-                                var ps = new ProcessBuilder(cLangLocation,
-                                                            sourceFilePath,
-                                                            compiler.strOutputSwitch(),
-                                                            binaryPath,
-                                                            compiler.strArchitectureFlag(architecture),
-                                                            compiler.strOptFlag(optimize));
-                                System.out.println(ps.command().toString());
-                                ps.redirectErrorStream(true);
-                                var compilationProcess = ps.start();
-                                var reader = new BufferedReader(new InputStreamReader(compilationProcess.getInputStream()));
-                                String line;
-                                while ((line = reader.readLine()) != null) {
-                                    System.out.println(line);
-                                }
-                                compilationProcess.waitFor();
-                                return binaryPath;
-                            });
-                            //Generate LLVM
-                            tasks.add(() -> {
-                                var ps = new ProcessBuilder(cLangLocation,
-                                                            sourceFilePath, "-S", "-emit-llvm",
-                                                            compiler.strOutputSwitch(),
-                                                            llvmPath,
-                                                            compiler.strArchitectureFlag(architecture),
-                                                            compiler.strOptFlag(optimize));
-                                System.out.println(ps.command().toString());
-                                ps.redirectErrorStream(true);
-                                var compilationProcess = ps.start();
-                                var reader = new BufferedReader(new InputStreamReader(compilationProcess.getInputStream()));
-                                String line;
-                                while ((line = reader.readLine()) != null) {
-                                    System.out.println(line);
-                                }
-                                compilationProcess.waitFor();
-                                return llvmPath;
-                            });
-                        }
-                    }
-                }
-                var results = EXEC.invokeAll(tasks);
-            }
+                for (CompilerConfig config : CompilerConfig.configs)
+                {
+                    var binaryPath = IOElements.strBinaryFullFileName(containerIndex, testIndex, config.arch, config.compiler, config.optimization);
+                    var llvmPath = IOElements.strLLVMFullFileName(containerIndex, testIndex, config.arch, config.compiler, config.optimization);
 
+                    //task definition for either binary or LLVM IR generation
+                    final var mode_LLVM_IR = true;
+                    final var mode_binary = false;
+                    java.util.function.Function<Boolean, Callable<String>> compilationTask = (mode) -> {
+                        return () -> {
+                            List<String> parameters;
+                            String targetFilePath;
+                            boolean generate_LLVM_IR;
+
+                            if (mode == mode_binary) {
+                                targetFilePath = binaryPath;
+                                generate_LLVM_IR = false;
+                            }
+                            else {
+                                targetFilePath = llvmPath;
+                                generate_LLVM_IR = true;
+                            }
+                            //todo parameters bepalen
+                            parameters = config.compileCommandParameters(sourceFilePath, targetFilePath, generate_LLVM_IR);
+
+                            var ps = new ProcessBuilder(parameters);
+                            System.out.println(ps.command().toString());
+                            ps.redirectErrorStream(true);
+                            var compilationProcess = ps.start();
+                            var reader = new BufferedReader(new InputStreamReader(compilationProcess.getInputStream()));
+                            String line;
+                            while ((line = reader.readLine()) != null) {
+                                System.out.println(line);
+                            }
+                            int returncode = compilationProcess.waitFor();
+                            if (returncode != 0) {
+                                String errorMessage = "Compiler exit code " + returncode + ", parameters: " + parameters;
+                                System.out.println(errorMessage);
+                                throw new Exception(errorMessage);
+                            }
+                            return targetFilePath;
+                        };
+                    };
+
+                    tasks.add( compilationTask.apply(mode_binary) );
+                    tasks.add( compilationTask.apply(mode_LLVM_IR) );
+                }
+
+                System.out.print("compiling ");
+                var results = EXEC.invokeAll(tasks);
+                System.out.println(" done");
+            }
         }
     }
 }

--- a/src/main/java/nl/ou/debm/producer/Main.java
+++ b/src/main/java/nl/ou/debm/producer/Main.java
@@ -69,7 +69,7 @@ public class Main {
                                 targetFilePath = llvmPath;
                                 generate_LLVM_IR = true;
                             }
-                            //todo parameters bepalen
+
                             parameters = config.compileCommandParameters(sourceFilePath, targetFilePath, generate_LLVM_IR);
 
                             var ps = new ProcessBuilder(parameters);

--- a/src/main/java/nl/ou/debm/test/AssessorTest.java
+++ b/src/main/java/nl/ou/debm/test/AssessorTest.java
@@ -1,6 +1,7 @@
 package nl.ou.debm.test;
 
 import nl.ou.debm.assessor.Assessor;
+import nl.ou.debm.common.Environment;
 import nl.ou.debm.common.IAssessor;
 import nl.ou.debm.common.IOElements;
 import nl.ou.debm.common.antlr.CLexer;
@@ -12,7 +13,6 @@ import java.io.IOException;
 import java.nio.file.*;
 
 import static nl.ou.debm.common.IOElements.strCSourceFullFilename;
-import static nl.ou.debm.common.Misc.strGetContainersBaseFolder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -20,9 +20,7 @@ public class AssessorTest {
     @Test
     public void doesAPerfectDecompilerGetFullScore() throws Exception {
         //We copy one existing container with one test
-        var strContainersBaseFolder = strGetContainersBaseFolder();
         var strDecompileScript = Paths.get(new File("").getAbsolutePath(), "scripts", "theperfectdecompiler.bat").toString();
-        IOElements.setBasePath(strContainersBaseFolder);
 
         // get name of the decompiler-script and test its existence & executableness
         if (!Files.isExecutable(Paths.get(strDecompileScript))) {
@@ -32,7 +30,7 @@ public class AssessorTest {
         var tempDir = Files.createTempDirectory("debm");
 
         //Look up first container dir
-        var firstContainer = Files.list(Path.of(strContainersBaseFolder)).findFirst();
+        var firstContainer = Files.list(Path.of(Environment.containerBasePath)).findFirst();
         if(!firstContainer.isPresent())
             fail("No containers found!");
 

--- a/src/main/java/nl/ou/debm/test/GeneratorTest.java
+++ b/src/main/java/nl/ou/debm/test/GeneratorTest.java
@@ -20,9 +20,7 @@ public class GeneratorTest {
         final var amountOfSources = 1;
 
         //1. Initialize folder structure
-        // set base path for all container operations, use a hack to differentiate between Reijer & Jaap & Kesava
-        IOElements.setBasePath(Misc.strGetContainersBaseFolder());
-        var containersFolder = new File(IOElements.getBasePath());
+        var containersFolder = new File(Environment.containerBasePath);
         if (!containersFolder.exists() && !containersFolder.mkdirs())
             throw new Exception("Unable to create containers folder");
 


### PR DESCRIPTION
- improved how compilers are called
- Environment class to define in one place what kind of environment this is

Dit omvat in ieder geval dat de compilers op de juiste manier worden aangeroepen (met march=i686 voor 32-bit in plaats van march=native). Om dat voor elkaar te krijgen moest ik een en ander wat herstructureren, want ik gebruik de clang gedistribueerd door winlibs, en die kan ofwel 64- of 32-bit maar niet beide. Ik heb dus voor beide architecturen (x86 en x86-64) een verschillend compilerpad nodig.

## per compilerconfiguratie het pad apart kunnen instellen

Om het zo flexibel mogelijk te maken heb ik de klasse CompilerConfig in het leven geroepen. Voor iedere combinatie van compiler, architectuur, optimalisatie en wordt een CompilerConfig gemaakt:

```java
for (var compiler : ECompiler.values())
for (var arch : EArchitecture.values())
for (var optimization : EOptimize.values())
{
    var config = new CompilerConfig();
    config.compiler = compiler;
    config.arch = arch;
    config.optimization = optimization;

    //determine path based on the environment
    if (Environment.actual == Environment.EnvEnum.KESAVA) {
        //use a different path for the 32-bit compiler
        if (arch == EArchitecture.X86ARCH && compiler == ECompiler.CLANG) {
            config.path = "C:\\winlibs-i686-posix-dwarf-gcc-13.2.0-llvm-17.0.6-mingw-w64msvcrt-11.0.1-r3\\mingw32\\bin\\clang.exe";
        }
    }
    configs.add(config);
}
```

Daardoor kan voor iedere CompilerConfig afzonderlijk het pad worden aangepast, afhankelijk van de omgeving. We kunnen zo allemaal zorgen dat het werkt zonder elkaar in de weg te zitten.

De mainfunctie loopt nu over de statische lijst van CompilerConfigs:

```java
for (CompilerConfig config : CompilerConfig.configs)
{
...
```

## commandoparameters instellen met regels

Wat ik ook heb veranderd is hoe commandoparameters worden bepaald. Dat is nu 1 functie:

```java
public List<String> compileCommandParameters(
            String sourceFilePath,
            String targetFilePath,
            boolean generate_LLVM_IR
    ) throws Exception {
        List<String> ret = new ArrayList<>();

        if (compiler == ECompiler.CLANG) {
            ret.add(getPath());
            ret.add(sourceFilePath);
            ret.add("-o"); ret.add(targetFilePath);

            if (optimization == EOptimize.OPTIMIZE)
                ret.add("-O3");
            else
                ret.add("-O0"); //this is also the default

            switch (arch) {
                case X64ARCH -> {
                    ret.add("-march=x86-64");
                    ret.add("-m64");
                }
                case X86ARCH -> {
                    ret.add("-march=i686");
                    ret.add("-m32");
                }
            }

            if (generate_LLVM_IR) {
                ret.add("-S");
                ret.add("-emit-llvm");
            }
        }

        return ret;
    }
```

Het voordeel daarvan is ook meer flexibiliteit. wat ik nodig had. Er was eerst een functie die "de"  architectuurvlag bepaalde, maar voor sommige architecturen heb je misschien meerdere vlaggen nodig (of geen). Dat geldt ook voor optimalisatie maar expliciet "-O0" geven vind ik wel zinvol voor de duidelijkheid, ook al is het de standaard.