### PR TITLE
Support unreachable functions

### DIFF
--- a/src/main/java/nl/ou/debm/producer/CGenerator.java
+++ b/src/main/java/nl/ou/debm/producer/CGenerator.java
@@ -405,7 +405,10 @@ public class CGenerator {
                 currentFeature = features.get(iNextFeatureIndex());
                 if (currentFeature instanceof IFunctionGenerator functionGenerator) {
                     Function newFunction = null;
-                    while(newFunction == null || !newFunction.isCallable()) {
+                    
+                    //To prevent an infinite loop, we allow features to deliver no more than 1000 unreachable functions in a row.
+                    var loopLimit = 100;
+                    while(newFunction == null || !newFunction.isCallable() && loopLimit-- > 0) {
                         // feature has a function generator, so use it
                         newFunction = functionGenerator.getNewFunction(type, withParameters);
 

--- a/src/main/java/nl/ou/debm/producer/CGenerator.java
+++ b/src/main/java/nl/ou/debm/producer/CGenerator.java
@@ -404,11 +404,12 @@ public class CGenerator {
             for (int count = 0; count < features.size(); count ++) {   // only loop all the features once
                 currentFeature = features.get(iNextFeatureIndex());
                 if (currentFeature instanceof IFunctionGenerator functionGenerator) {
-                    Function newFunction = null;
-                    
+                    Function newFunction;
+
                     //To prevent an infinite loop, we allow features to deliver no more than 1000 unreachable functions in a row.
                     var loopLimit = 100;
-                    while(newFunction == null || !newFunction.isCallable() && loopLimit-- > 0) {
+
+                    do {
                         // feature has a function generator, so use it
                         newFunction = functionGenerator.getNewFunction(type, withParameters);
 
@@ -419,7 +420,11 @@ public class CGenerator {
                         if (newFunction.isCallable())
                             addFunctionToCallableFunctionsByReturnType(newFunction);
                         functions.add(newFunction);
-                    }
+                    } while(!newFunction.isCallable() && loopLimit-- > 0);
+
+                    if(!newFunction.isCallable())
+                        throw new RuntimeException(currentFeature.getClass().getName() + " does not produce a callable function after " + loopLimit + " tries");
+
                     return newFunction;
                 }
             }

--- a/src/main/java/nl/ou/debm/producer/Function.java
+++ b/src/main/java/nl/ou/debm/producer/Function.java
@@ -12,6 +12,7 @@ public class Function {
     private final List<FunctionParameter> parameters = new ArrayList<>();   // function parameter list
     private final List<String> statements = new ArrayList<>();  // function statements
     private boolean hasVarArgs = false;
+    private boolean isCallable = true;
 
     /**
      * Construct a function object
@@ -108,4 +109,12 @@ public class Function {
      * @param newStatements String list containing new statements
      */
     public void addStatements(List<String> newStatements) {statements.addAll(newStatements);}
+
+    public boolean isCallable() {
+        return isCallable;
+    }
+
+    public void setCallable(boolean callable) {
+        isCallable = callable;
+    }
 }


### PR DESCRIPTION
An IFunctionGenerator can now mark a function as not callable.

Normally, every function is directly used after creation, by design (to prevent unreachable functions).
This way, the CGenerator asks for function definitions in a loop, until it gets a callable function.

To prevent an infinite loop, I added a maximum to it, after which I throw a RuntimeException.