### PR TITLE
decompiler explorer werkt

### DIFF
--- a/src/main/java/nl/ou/debm/common/Environment.java
+++ b/src/main/java/nl/ou/debm/common/Environment.java
@@ -7,6 +7,7 @@ package nl.ou.debm.common;
 public class Environment {
     public static EEnv actual;
     public static String containerBasePath;
+    public static String decompilerPath; //where are the decompilers located
 
     public enum EEnv {
         KESAVA,
@@ -24,10 +25,17 @@ public class Environment {
 
         //set containerBaseFolder
         containerBasePath = switch (actual) {
-            case KESAVA -> "C:\\OU\\IB9902, IB9906 - Afstudeerproject\\_repo\\decompiler-benchmarking\\containers\\";
+            case KESAVA -> "C:\\OU\\IB9902, IB9906 - Afstudeerproject\\_repo\\_containers\\";
             case JAAP -> "/home/jaap/VAF/containers/";
             case REIJER -> "C:\\Users\\reije\\OneDrive\\Documenten\\Development\\c-program\\containers\\";
             case DEFAULT -> "containers";
+        };
+
+        decompilerPath = switch (actual) {
+            case KESAVA -> "C:\\OU\\IB9902, IB9906 - Afstudeerproject\\_repo\\_decompilers\\";
+            case JAAP -> "scripts";
+            case REIJER -> "scripts";
+            case DEFAULT -> "scripts";
         };
 
         System.out.println("using environment " + actual.toString());

--- a/src/main/java/nl/ou/debm/common/IOElements.java
+++ b/src/main/java/nl/ou/debm/common/IOElements.java
@@ -23,7 +23,7 @@ public class IOElements {
     private static final String binaryPrefix = "binary_";
     private static final String binaryPostfix = ".exe";
     private static final String llvmPrefix = "llvm_";
-    private static final String llvmPostfix = ".llvm";
+    private static final String llvmPostfix = ".llvm"; //todo clang gebruikt extensie ll voor llvm ir en s voor assembly
     private static final String cSourceName = "source.c";
     private static final String containerFolderPrefix = "container_";
     private static final String testFolderPrefix = "test_";

--- a/src/main/java/nl/ou/debm/devtools/explorer/ICancellableTask.java
+++ b/src/main/java/nl/ou/debm/devtools/explorer/ICancellableTask.java
@@ -1,0 +1,8 @@
+package nl.ou.debm.devtools.explorer;
+
+public interface ICancellableTask {
+    void run();
+    void cancel();
+    void await() throws InterruptedException;
+    boolean is_running();
+}

--- a/src/main/java/nl/ou/debm/devtools/explorer/ListeningButton.java
+++ b/src/main/java/nl/ou/debm/devtools/explorer/ListeningButton.java
@@ -1,0 +1,25 @@
+package nl.ou.debm.devtools.explorer;
+
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import javax.swing.JButton;
+
+/*
+This class is a JButton that is its own MouseListener. Example usage:
+ListeningButton button = new ListeningButton("click here") {
+ 	public void mouseReleased(MouseEvent e) {
+ 		System.out.println("MouseReleased has taken place.");
+ 	}
+ };
+*/
+public class ListeningButton extends JButton implements MouseListener {
+    public ListeningButton(String text) {
+        super(text);
+        this.addMouseListener(this);
+    }
+    public void mouseReleased(MouseEvent e) {}
+    public void mousePressed(MouseEvent e) {}
+    public void mouseClicked(MouseEvent e) {}
+    public void mouseEntered(MouseEvent e) {}
+    public void mouseExited(MouseEvent e) {}
+}

--- a/src/main/java/nl/ou/debm/devtools/explorer/Main.java
+++ b/src/main/java/nl/ou/debm/devtools/explorer/Main.java
@@ -1,0 +1,458 @@
+package nl.ou.debm.devtools.explorer;
+
+
+import nl.ou.debm.common.*;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.MouseEvent;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+
+class Constants {
+    public static String temp_dir = Environment.decompilerPath + "temp\\";
+}
+
+public class Main {
+    public static void main(String[] args) throws Exception
+    {
+        new Controller();
+    }
+}
+
+
+//Every "decompiler" here is assumed to be an executable or script that accepts two parameters: the program to be decompiled and the location of the decompiled C. Decompilers that work differently will need a wrapper script of this form.
+class Decompiler {
+    String path;
+    String name;
+    SingleInstanceTask decompilationTask = new SingleInstanceTask();
+}
+
+class Controller {
+    GUI gui;
+    List<Decompiler> decompilers = new ArrayList<>();
+    SingleInstanceTask compilationTask = new SingleInstanceTask();
+    SingleInstanceTask compilationTask_LLVM_IR = new SingleInstanceTask();
+    SingleInstanceTask compilationTask_assembly = new SingleInstanceTask();
+    static String compilerPath = "";
+
+    public Controller() throws Exception {
+        //Find the decompilers
+        File dir = new File(Environment.decompilerPath);
+        for (File file : dir.listFiles()) {
+            if (file.isDirectory()) continue;
+            var d = new Decompiler();
+            d.path = file.getPath();
+            d.name = file.getName();
+            decompilers.add(d);
+        }
+
+        System.out.println("Decompilers found:");
+        decompilers.forEach(elt -> System.out.println(elt.name + " at " + elt.path));
+        System.out.println("done");
+
+        //ensure that the temp directory exists (if so this will do nothing)
+        Files.createDirectories(Path.of(Constants.temp_dir));
+
+        SwingUtilities.invokeLater(() -> {
+            try {
+                gui = new GUI(this);
+                compile(); //start compilation and decompilation immediately at startup
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+
+    //Define the names of the used files
+    static String source_filePath() { return Constants.temp_dir + "source.c"; }
+    static String compiled_binary_filePath() { return Constants.temp_dir + "compiled.exe"; }
+    static String compiled_assembly_filePath() { return Constants.temp_dir + "compiled.s"; }
+    static String compiled_LLVM_IR_filePath() { return Constants.temp_dir + "compiled.ll"; }
+    static String decompiled_C_FilePath(Decompiler d) {
+        return Constants.temp_dir + d.name + "-result.c";
+    }
+
+    public void compile() throws Exception {
+        var flags = gui.compilerGUIElements.source_field_flags.getText().split(" ");
+        var c_code = gui.compilerGUIElements.source_codeArea.getText();
+        compile(c_code, new ArrayList<String>(List.of(flags)));
+    }
+
+    //This also starts decompilation tasks after compilation is done.
+    public void compile(String code, List<String> extra_compilerParams) throws Exception {
+        System.out.println("new compilation");
+
+        //set the compiler path if not set already. Clang is used.
+        if (compilerPath == "") {
+            compilerPath = Misc.strGetExternalSoftwareLocation(ECompiler.CLANG.strProgramName());
+        }
+
+        // All tasks are ended, because a new compilation means that everything has to be done again (including decompilation). This is not necessary for correctness. It's just to prevent, for example, unnecessary decompilation processes from using up CPU time until they are eventually cancelled anyway, because setInstance also cancels any current tasks.
+        compilationTask.cancel();
+        compilationTask_assembly.cancel();
+        compilationTask_LLVM_IR.cancel();
+        decompilers.forEach(d -> {
+            try {
+                d.decompilationTask.cancel();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        compilationTask.setInstance(new ProcessTask(() -> {
+            //write source code to file
+            try {
+                IOElements.writeToFile(code, source_filePath());
+                System.out.println("source code written to " + source_filePath());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+
+            //update the GUI
+            gui.compilerGUIElements.source_label_status.setText("compiling");
+
+            //define commandline parameters
+            var compilerParams = new ArrayList<String>();
+            compilerParams.add(compilerPath);
+            compilerParams.add(source_filePath());
+            compilerParams.add("-o"); compilerParams.add(compiled_binary_filePath());
+            compilerParams.addAll(extra_compilerParams);
+
+            //create compilation process
+            var procBuilder = new ProcessBuilder(compilerParams);
+            System.out.println("defined process: " + compilerParams.toString());
+            procBuilder.redirectErrorStream(true);
+            return procBuilder;
+        }, (result) -> {
+            //This is the callback.
+            try {
+                on_compilation_done(result);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }));
+
+        //Compile again to obtain LLVM IR. Decompilation takes place only after the task that compiles the binary is done. This task is just to show LLVM IR in the GUI.
+        compilationTask_LLVM_IR.setInstance(new ProcessTask(() -> {
+            //update the GUI
+            gui.compilerGUIElements.LLVM_IR_label_status.setText("compiling");
+
+            //define commandline parameters
+            var compilerParams = new ArrayList<String>();
+            compilerParams.add(compilerPath);
+            compilerParams.add(source_filePath());
+            compilerParams.add("-o"); compilerParams.add(compiled_LLVM_IR_filePath());
+            compilerParams.add("-S"); compilerParams.add("-emit-llvm");
+            compilerParams.addAll(extra_compilerParams);
+
+            //create compilation process
+            var procBuilder = new ProcessBuilder(compilerParams);
+            System.out.println("defined process: " + compilerParams.toString());
+            procBuilder.redirectErrorStream(true);
+            return procBuilder;
+        }, (result) -> {
+            //This is the callback.
+            try {
+                on_compilation_LLVM_IR_done(result);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }));
+
+        //Compile again to obtain assembly code.
+        compilationTask_assembly.setInstance(new ProcessTask(() -> {
+            //update the GUI
+            gui.compilerGUIElements.assembly_label_status.setText("compiling");
+
+            //define commandline parameters
+            var compilerParams = new ArrayList<String>();
+            compilerParams.add(compilerPath);
+            compilerParams.add(source_filePath());
+            compilerParams.add("-o"); compilerParams.add(compiled_assembly_filePath());
+            compilerParams.add("-S");
+            compilerParams.addAll(extra_compilerParams);
+
+            //create compilation process
+            var procBuilder = new ProcessBuilder(compilerParams);
+            System.out.println("defined process: " + compilerParams.toString());
+            procBuilder.redirectErrorStream(true);
+            return procBuilder;
+        }, (result) -> {
+            //This is the callback.
+            try {
+                on_compilation_assembly_done(result);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }));
+    }
+
+    //Starts decompilation and updates the GUI
+    public void on_compilation_done(ProcessResult compilation_result) throws Exception {
+        System.out.println("on_compilation_done");
+        if (compilation_result.exitCode != 0) {
+            System.out.println("The compiler terminated abnormally.");
+            gui.compilerGUIElements.source_label_status.setText("ready (with errors)");
+            //I put the compilation errors in the LLVM IR code area. This does not really make sense but I need somewhere to put it without overwriting the C source code that the user wrote. If regular compilation fails, LLVM IR compilation will probably also fail and vice versa, so it's not really a problem to ignore console output for LLVM IR compilation errors. Quick and dirty
+            gui.compilerGUIElements.LLVM_IR_codeArea.setText(compilation_result.consoleOutput);
+            return;
+        }
+
+        if ( ! IOElements.bFileExists(compiled_binary_filePath())) {
+            //todo throw exception?
+            System.out.println("Error: compiled program does not exist.");
+            return;
+        }
+
+        //If here there were no errors.
+
+        //Update the GUI
+        gui.compilerGUIElements.source_label_status.setText("ready");
+
+        //Start decompilation tasks
+        decompilers.forEach(decompiler ->
+        {
+            //todo waarom is hier try-catch nodig en in de methode compile niet? volgens mij is de vorm exact hetzelfde...
+            try {
+                decompiler.decompilationTask.setInstance(new ProcessTask(() -> {
+                    //update the GUI
+                    gui.decompilerGUIElements.get(decompiler.name).label_status.setText("decompiling");
+
+                    //define commandline parameters
+                    var decompilerParams = new ArrayList<String>();
+                    decompilerParams.add(decompiler.path);
+                    decompilerParams.add(compiled_binary_filePath());
+                    decompilerParams.add(decompiled_C_FilePath(decompiler));
+
+                    //create decompilation process
+                    var procBuilder = new ProcessBuilder(decompilerParams);
+                    System.out.println("defined process: " + decompilerParams.toString());
+                    procBuilder.redirectErrorStream(true);
+                    return procBuilder;
+                }, (result) -> {
+                    //This is the callback.
+                    System.out.println("callback van decompiler");
+                    try {
+                        on_decompilation_done(decompiler, result);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    //Updates the GUI with decompiled code
+    public void on_decompilation_done(Decompiler d, ProcessResult result) throws Exception {
+        System.out.println("on_decompilation_done");
+        if (result.exitCode != 0) {
+            System.out.println("The decompiler terminated abnormally.");
+            gui.decompilerGUIElements.get(d.name).label_status.setText("ready (with errors)");
+            gui.decompilerGUIElements.get(d.name).codeArea.setText(result.consoleOutput);
+            return;
+        }
+        if ( ! IOElements.bFileExists(decompiled_C_FilePath(d))) {
+            System.out.println("error: Decompiled code file does not exist");
+            return;
+        }
+        String decompiled_code = Files.readString(Path.of(decompiled_C_FilePath(d)));
+        gui.decompilerGUIElements.get(d.name).label_status.setText("ready");
+        gui.decompilerGUIElements.get(d.name).codeArea.setText(decompiled_code);
+    }
+
+    public void on_compilation_LLVM_IR_done(ProcessResult result) throws Exception {
+        System.out.println("on_compilation_LLVM_IR_done");
+        if (result.exitCode != 0) {
+            System.out.println("The compiler (LLVM IR) terminated abnormally.");
+            //I do not show the console output in the LLVM IR code area because it's already in use for binary compilation errors.
+            gui.compilerGUIElements.LLVM_IR_label_status.setText("ready (with errors)");
+            return;
+        }
+        if ( ! IOElements.bFileExists(compiled_LLVM_IR_filePath())) {
+            System.out.println("error: LLVM IR code file does not exist");
+            return;
+        }
+        String compiled_LLVM_IR = Files.readString(Path.of(compiled_LLVM_IR_filePath()));
+        gui.compilerGUIElements.LLVM_IR_codeArea.setText(compiled_LLVM_IR);
+        gui.compilerGUIElements.LLVM_IR_label_status.setText("ready");
+    }
+
+    public void on_compilation_assembly_done(ProcessResult result) throws Exception {
+        System.out.println("on_compilation_assembly_done");
+        if (result.exitCode != 0) {
+            System.out.println("The compiler (assembly) terminated abnormally.");
+            gui.compilerGUIElements.assembly_codeArea.setText(result.consoleOutput);
+            gui.compilerGUIElements.assembly_label_status.setText("ready (with errors)");
+            return;
+        }
+        if ( ! IOElements.bFileExists(compiled_assembly_filePath())) {
+            System.out.println("error: assembly code file does not exist");
+            return;
+        }
+        String compiled_assembly = Files.readString(Path.of(compiled_assembly_filePath()));
+        gui.compilerGUIElements.assembly_codeArea.setText(compiled_assembly);
+        gui.compilerGUIElements.assembly_label_status.setText("ready");
+    }
+}
+
+class DecompilerGUIElements {
+    JLabel label_name;
+    JLabel label_status;
+    JTextArea codeArea;
+}
+
+class CompilerGUIElements {
+    JButton compileButton;
+
+    JTextArea source_codeArea;
+    JLabel source_label_status;
+    JTextField source_field_flags;
+    JLabel source_label_flags;
+
+    JTextArea assembly_codeArea;
+    JLabel assembly_label_name;
+    JLabel assembly_label_status;
+
+    JTextArea LLVM_IR_codeArea;
+    JLabel LLVM_IR_label_name;
+    JLabel LLVM_IR_label_status;
+}
+
+class Util {
+    static JTextArea lineWrappedTextArea() {
+        var ret = new JTextArea();
+        ret.setLineWrap(true);
+        ret.setWrapStyleWord(true);
+        return ret;
+    }
+}
+
+class GUI extends JFrame {
+    Controller controller;
+    //The following are references to some GUI elements. Not all GUI elements are stored in this class because not all elements need to be referenced.
+    Map<String, DecompilerGUIElements> decompilerGUIElements = new HashMap<>(); //maps the decompiler name to the corresponding text area
+    CompilerGUIElements compilerGUIElements = new CompilerGUIElements();
+
+    public GUI(Controller controller_) throws Exception {
+        controller = controller_;
+        setVisible(true);
+        setDefaultCloseOperation(EXIT_ON_CLOSE);
+        setSize(800, 600);
+        setContentPane(main_panel());
+    }
+
+    private JPanel main_panel() {
+        var ret = new JPanel();
+        //The main panel is divided into columns. The compiler related GUI elements use two columns. Then there's a column for each decompiler. Because there is a varying number of columns I set it to 0 here, which means new columns will be created as necessary.
+        ret.setLayout(new GridLayout(1, 0));
+        compilerPanels().forEach(ret::add);
+        controller.decompilers.forEach(decompiler -> {
+            ret.add(decompilerPanel(decompiler));
+        });
+        return ret;
+    }
+
+    private List<JPanel> compilerPanels() {
+        var ret = new ArrayList<JPanel>();
+
+        compilerGUIElements.assembly_codeArea = Util.lineWrappedTextArea();
+        compilerGUIElements.assembly_label_name = new JLabel("assembly");
+        compilerGUIElements.assembly_label_status = new JLabel("ready");
+        compilerGUIElements.source_codeArea = Util.lineWrappedTextArea();
+        compilerGUIElements.source_codeArea.setText("int main() { return 0; }");
+        compilerGUIElements.source_label_status = new JLabel("ready");
+        compilerGUIElements.source_field_flags = new JTextField();
+        compilerGUIElements.source_label_flags = new JLabel("flags");
+        compilerGUIElements.LLVM_IR_codeArea = Util.lineWrappedTextArea();
+        compilerGUIElements.LLVM_IR_label_name = new JLabel("LLVM IR");
+        compilerGUIElements.LLVM_IR_label_status = new JLabel("ready");
+        compilerGUIElements.compileButton = new ListeningButton("Compile and decompile") {
+            public void mouseClicked(MouseEvent e) {
+                try {
+                    controller.compile();
+                } catch (Exception ex) {
+                    throw new RuntimeException(ex);
+                }
+            }
+        };
+
+        var source_panel = new JPanel();
+        source_panel.setLayout(new BorderLayout());
+        var source_panel_north = new JPanel();
+        source_panel_north.setLayout(new GridLayout(2, 2));
+        source_panel_north.add(compilerGUIElements.compileButton);
+        source_panel_north.add(compilerGUIElements.source_label_status);
+        source_panel_north.add(compilerGUIElements.source_label_flags);
+        source_panel_north.add(compilerGUIElements.source_field_flags);
+        source_panel.add(source_panel_north, BorderLayout.NORTH);
+        source_panel.add(new JScrollPane(compilerGUIElements.source_codeArea), BorderLayout.CENTER);
+
+        var assembly_panel = new JPanel();
+        assembly_panel.setLayout(new BorderLayout());
+        var assembly_panel_north = new JPanel();
+        assembly_panel_north.setLayout(new GridLayout(0, 2));
+        assembly_panel_north.add(compilerGUIElements.assembly_label_name);
+        assembly_panel_north.add(compilerGUIElements.assembly_label_status);
+        assembly_panel.add(assembly_panel_north, BorderLayout.NORTH);
+        assembly_panel.add(new JScrollPane(compilerGUIElements.assembly_codeArea), BorderLayout.CENTER);
+
+        var LLVM_IR_panel = new JPanel();
+        LLVM_IR_panel.setLayout(new BorderLayout());
+        var LLVM_IR_panel_north = new JPanel();
+        LLVM_IR_panel_north.setLayout(new GridLayout(0,2));
+        LLVM_IR_panel_north.add(compilerGUIElements.LLVM_IR_label_name);
+        LLVM_IR_panel_north.add(compilerGUIElements.LLVM_IR_label_status);
+        LLVM_IR_panel.add(LLVM_IR_panel_north, BorderLayout.NORTH);
+        LLVM_IR_panel.add(new JScrollPane(compilerGUIElements.LLVM_IR_codeArea), BorderLayout.CENTER);
+
+        // I use two columns for compiler related elements. The left panel will contain the source code and assembly. The right panel will contain the LLVM IR. In this way, more space is reserved for LLVM IR.
+        var left = new JPanel();
+        var right = new JPanel();
+        left.setLayout(new GridLayout(2,0));
+        left.add(source_panel);
+        left.add(assembly_panel);
+        right.setLayout(new GridLayout(1,1));
+        right.add(LLVM_IR_panel);
+
+        ret.add(left);
+        ret.add(right);
+        return ret;
+    }
+
+    private JPanel decompilerPanel(Decompiler decompiler) {
+        var ret = new JPanel();
+        ret.setLayout(new BorderLayout());
+        ret.setBackground(new Color(0,255,255)); //todo
+
+        var elts = new DecompilerGUIElements();
+        elts.codeArea = new JTextArea();
+        elts.codeArea.setLineWrap(true);
+        elts.codeArea.setWrapStyleWord(true);
+        elts.label_name = new JLabel(decompiler.name);
+        elts.label_status = new JLabel("ready");
+        decompilerGUIElements.put(decompiler.name, elts);
+
+        var north = new JPanel();
+        north.setLayout(new GridLayout(0, 2));
+        north.add(elts.label_name);
+        north.add(elts.label_status);
+
+        var center = new JScrollPane(elts.codeArea);
+
+        ret.add(north, BorderLayout.NORTH);
+        ret.add(center, BorderLayout.CENTER);
+
+        return ret;
+    }
+}

--- a/src/main/java/nl/ou/debm/devtools/explorer/Main.java
+++ b/src/main/java/nl/ou/debm/devtools/explorer/Main.java
@@ -240,7 +240,6 @@ class Controller {
                     return procBuilder;
                 }, (result) -> {
                     //This is the callback.
-                    System.out.println("callback van decompiler");
                     try {
                         on_decompilation_done(decompiler, result);
                     } catch (Exception e) {
@@ -433,7 +432,6 @@ class GUI extends JFrame {
     private JPanel decompilerPanel(Decompiler decompiler) {
         var ret = new JPanel();
         ret.setLayout(new BorderLayout());
-        ret.setBackground(new Color(0,255,255)); //todo
 
         var elts = new DecompilerGUIElements();
         elts.codeArea = new JTextArea();

--- a/src/main/java/nl/ou/debm/devtools/explorer/ProcessTask.java
+++ b/src/main/java/nl/ou/debm/devtools/explorer/ProcessTask.java
@@ -32,7 +32,6 @@ public class ProcessTask implements ICancellableTask {
                         proc = procBuilder.start();
                         process_created = true;
                     }
-                    System.out.println("proces gestart: " + proc.pid());
 
                     var waiter_thread = new Thread(() -> {
                         //a lot of boilerplate to get the console output. I need it, but it's also necessary to read it, otherwise the process will never terminate. See for example https://stackoverflow.com/questions/3285408/java-processbuilder-resultant-process-hangs
@@ -41,12 +40,12 @@ public class ProcessTask implements ICancellableTask {
                         final String consoleOutput = stdoutReader.lines().collect(Collectors.joining(System.lineSeparator()));
 
                         try {
-                            System.out.println("het wachten is begonnen");
+                            System.out.println("waiting for process " + proc.pid());
                             proc.waitFor();
                         } catch (InterruptedException e) {
                             throw new RuntimeException(e);
                         }
-                        System.out.println("klaar met wachten op het proces " + proc.pid());
+                        System.out.println("done waiting for process " + proc.pid());
 
                         ProcessResult result = new ProcessResult();
                         result.exitCode = proc.exitValue();
@@ -64,7 +63,6 @@ public class ProcessTask implements ICancellableTask {
                         });
                     });
                     waiter_thread.start();
-                    System.out.println("wachtthread gestart " + proc.pid());
 
                 } catch (IOException e) {
                     throw new RuntimeException(e);

--- a/src/main/java/nl/ou/debm/devtools/explorer/ProcessTask.java
+++ b/src/main/java/nl/ou/debm/devtools/explorer/ProcessTask.java
@@ -1,0 +1,97 @@
+package nl.ou.debm.devtools.explorer;
+
+import javax.swing.*;
+import java.io.*;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+class ProcessResult {
+    int exitCode;
+    String consoleOutput;
+}
+/*
+
+ */
+public class ProcessTask implements ICancellableTask {
+    private Process proc;
+    private Runnable start_process;
+    private boolean m_is_running = false;
+    private boolean process_created = false;
+    private boolean cancelled = false;
+
+    ProcessTask(Supplier<ProcessBuilder> process_creator, Consumer<ProcessResult> callback) throws InterruptedException {
+        start_process = () -> {
+            m_is_running = true;
+
+            //create the process on the GUI thread because process_creator may use the GUI
+            SwingUtilities.invokeLater(() -> {
+                try {
+                    var procBuilder = process_creator.get();
+                    synchronized (this) {
+                        proc = procBuilder.start();
+                        process_created = true;
+                    }
+                    System.out.println("proces gestart: " + proc.pid());
+
+                    var waiter_thread = new Thread(() -> {
+                        //a lot of boilerplate to get the console output. I need it, but it's also necessary to read it, otherwise the process will never terminate. See for example https://stackoverflow.com/questions/3285408/java-processbuilder-resultant-process-hangs
+                        final InputStream stdoutInputStream = proc.getInputStream();
+                        final BufferedReader stdoutReader = new BufferedReader(new InputStreamReader(stdoutInputStream));
+                        final String consoleOutput = stdoutReader.lines().collect(Collectors.joining(System.lineSeparator()));
+
+                        try {
+                            System.out.println("het wachten is begonnen");
+                            proc.waitFor();
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                        System.out.println("klaar met wachten op het proces " + proc.pid());
+
+                        ProcessResult result = new ProcessResult();
+                        result.exitCode = proc.exitValue();
+                        result.consoleOutput = consoleOutput;
+
+                        //Do not execute the callback if the task was cancelled. Because the cancelled boolean is not protected by locks, cancelling does not guarantee anything. It is intended just to make the task end faster, including by skipping the callback. (In practice, given how this class is currently used, this prevents updating the GUI twice if a compilation/decompilation result of a cancelled task is already available.)
+                        //The callback is executed on the GUI thread, which is necessary if it uses the GUI, which my callbacks do. This also means that the waiter thread returns before the task is finished. By definition, I consider a task to be truly finished if it is not running anymore. To allow waiting for that condition, I call notifyAll after setting m_is_running.
+                        SwingUtilities.invokeLater(() -> {
+                            if ( ! cancelled)
+                                callback.accept(result);
+                            synchronized (this) {
+                                m_is_running = false;
+                                notifyAll();
+                            }
+                        });
+                    });
+                    waiter_thread.start();
+                    System.out.println("wachtthread gestart " + proc.pid());
+
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        };
+    }
+
+    public synchronized void run() {
+        assert !process_created; //Assumption: the task can only be run once.
+        start_process.run();
+    }
+
+    public synchronized void cancel() {
+        cancelled = true;
+        if (process_created)
+            proc.destroy(); //will do nothing if the process does not exist
+    }
+
+    public synchronized void await() throws InterruptedException {
+        assert process_created;
+        while (m_is_running) {
+            wait(); //wait for a notification that the task is not running anymore
+        }
+    }
+
+    public synchronized boolean is_running() {
+        return m_is_running;
+    }
+}

--- a/src/main/java/nl/ou/debm/devtools/explorer/SingleInstanceTask.java
+++ b/src/main/java/nl/ou/debm/devtools/explorer/SingleInstanceTask.java
@@ -1,0 +1,85 @@
+package nl.ou.debm.devtools.explorer;
+
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+
+/*
+What this class does:
+- It models a thread of executing that can, at any time, be either busy running its current task, or idle.
+- Initially there is no task, so the status is idle.
+- When a task is added (by calling run) any previous task is cancelled. This is what makes it a "single" instance task. Adding a new task means all previous tasks are now irrelevant and do not need to be finished.
+
+Example how this is useful: there should be at most one compilation task at any time. When the user clicks the compile button, any previous compilation can be cancelled because the new compilation task would overwrite the results anyway. This is mainly important for speed. The user should not have to wait for a task of which the result is not going to be used.
+
+Implementation detail: There is a currentTask but also a nextTask, so that the caller of setInstance can "enqueue" the task and continue without waiting for the execution to actually start. This is important to avoid a deadlock if both the task initiation and task completion must take place on the GUI thread (which is the case in this program). It also makes it easier to reason about correctness: all functions that acquire a lock perform just a quick action that needs no further locks and then release the lock.
+ */
+public class SingleInstanceTask {
+    enum EStatus {
+        idle, running, end_of_life //todo end_of_life is never set
+    }
+
+    ExecutorService exec = Executors.newFixedThreadPool(1);
+    Optional<ICancellableTask> next_task = Optional.empty();
+    Optional<ICancellableTask> current_task = Optional.empty();
+    EStatus status = EStatus.idle;
+
+    SingleInstanceTask() {
+        exec.submit(() -> {
+            try {
+                taskLoop();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+
+    //The purpose of taskLoop is to keep running new tasks as they become available
+    private void taskLoop() throws InterruptedException {
+        while(true)
+        {
+            System.out.println("weer in de loop");
+            //Note that taskLoop is the ONLY function that changes current_task, so it can safely check current_task.isPresent without holding a lock.
+            if (current_task.isPresent()) {
+                System.out.println("begint met wachten op current_task");
+                current_task.get().await();
+                System.out.println("klaar met wachten op current_task");
+            }
+
+            //Now it can be assumed that current_task has finished or does not exist at all.
+
+            synchronized (this) {
+                //wait until there is a next task. setInstance calls notifyAll on (this) so the waiting will end when there is a next task.
+                while ( ! next_task.isPresent()) {
+                    wait();
+                    if (status == EStatus.end_of_life)
+                        return;
+                }
+                //There is a next task. Make it the current task and continue.
+                current_task = next_task;
+                next_task = Optional.empty();
+                current_task.get().run(); //starts the task but does not block this thread
+            }
+        }
+    }
+
+    public synchronized void setInstance(ICancellableTask new_task) {
+        assert status != EStatus.end_of_life;
+        next_task = Optional.of(new_task);
+        if (current_task.isPresent()) {
+            current_task.get().cancel();
+        }
+        notifyAll();
+    }
+
+    public synchronized void cancel() throws InterruptedException {
+        if (next_task.isPresent()) {
+            next_task = Optional.empty();
+        }
+        if (current_task.isPresent()) {
+            current_task.get().cancel();
+        }
+    }
+}

--- a/src/main/java/nl/ou/debm/devtools/explorer/SingleInstanceTask.java
+++ b/src/main/java/nl/ou/debm/devtools/explorer/SingleInstanceTask.java
@@ -7,23 +7,18 @@ import java.util.concurrent.Executors;
 
 /*
 What this class does:
-- It models a thread of executing that can, at any time, be either busy running its current task, or idle.
-- Initially there is no task, so the status is idle.
-- When a task is added (by calling run) any previous task is cancelled. This is what makes it a "single" instance task. Adding a new task means all previous tasks are now irrelevant and do not need to be finished.
+- It models a thread of execution that can, at any time, be either busy running its current task, or idle.
+- Initially there is no task, so the thread is idle.
+- When a task is added (by calling setInstance) any previous task is cancelled. This is what makes it a "single" instance task. Adding a new task means all previous tasks are now irrelevant and do not need to be finished.
 
 Example how this is useful: there should be at most one compilation task at any time. When the user clicks the compile button, any previous compilation can be cancelled because the new compilation task would overwrite the results anyway. This is mainly important for speed. The user should not have to wait for a task of which the result is not going to be used.
 
 Implementation detail: There is a currentTask but also a nextTask, so that the caller of setInstance can "enqueue" the task and continue without waiting for the execution to actually start. This is important to avoid a deadlock if both the task initiation and task completion must take place on the GUI thread (which is the case in this program). It also makes it easier to reason about correctness: all functions that acquire a lock perform just a quick action that needs no further locks and then release the lock.
  */
 public class SingleInstanceTask {
-    enum EStatus {
-        idle, running, end_of_life //todo end_of_life is never set
-    }
-
     ExecutorService exec = Executors.newFixedThreadPool(1);
     Optional<ICancellableTask> next_task = Optional.empty();
     Optional<ICancellableTask> current_task = Optional.empty();
-    EStatus status = EStatus.idle;
 
     SingleInstanceTask() {
         exec.submit(() -> {
@@ -35,17 +30,13 @@ public class SingleInstanceTask {
         });
     }
 
-
     //The purpose of taskLoop is to keep running new tasks as they become available
     private void taskLoop() throws InterruptedException {
         while(true)
         {
-            System.out.println("weer in de loop");
             //Note that taskLoop is the ONLY function that changes current_task, so it can safely check current_task.isPresent without holding a lock.
             if (current_task.isPresent()) {
-                System.out.println("begint met wachten op current_task");
                 current_task.get().await();
-                System.out.println("klaar met wachten op current_task");
             }
 
             //Now it can be assumed that current_task has finished or does not exist at all.
@@ -54,8 +45,6 @@ public class SingleInstanceTask {
                 //wait until there is a next task. setInstance calls notifyAll on (this) so the waiting will end when there is a next task.
                 while ( ! next_task.isPresent()) {
                     wait();
-                    if (status == EStatus.end_of_life)
-                        return;
                 }
                 //There is a next task. Make it the current task and continue.
                 current_task = next_task;
@@ -66,7 +55,6 @@ public class SingleInstanceTask {
     }
 
     public synchronized void setInstance(ICancellableTask new_task) {
-        assert status != EStatus.end_of_life;
         next_task = Optional.of(new_task);
         if (current_task.isPresent()) {
             current_task.get().cancel();


### PR DESCRIPTION
Het werkt:

![image](https://github.com/reijer-dev/decompiler-benchmarking/assets/29734312/80351300-7e88-412b-b4eb-866c6db15ed7)

In Environment.java kun je kiezen waar jouw map met decompilers staat. Daar zoekt de decompiler explorer de decompilers.

Een decompiler in dit geval is een programma of script dat de volgende 2 parameters (en in deze volgorde) accepteert:
- een pad naar het bestand met C broncode;
- een pad naar het bestand waar de gedecompileerde C in moet komen.

Decompilers die niet van die vorm zijn hebben dus een wrapper-script nodig. Praktisch is dat dus bijna altijd nodig. Ik heb niet eens getest of het werkt met een echt programma maar het zou moeten werken.

Ik heb tot nu toe alleen retdec getest. Daarvoor heb ik in windows dit script:

```cmd
C:\software\RetDec-v5.0-Windows-Release\bin\retdec-decompiler.exe %1 -o %2
```

Dat heb ik opgeslagen als retdec.bat in de map waar de explorer decompilers zoekt. Ik heb het niet gecommit omdat de scripts per persoon verschillen wegens verschillende softwarelocaties en linux/windows o.a.