### PR TITLE
bugfix: default value for struct correctly implemented

### DIFF
--- a/src/main/java/nl/ou/debm/assessor/Assessor.java
+++ b/src/main/java/nl/ou/debm/assessor/Assessor.java
@@ -6,20 +6,15 @@ import nl.ou.debm.common.antlr.CParser;
 import nl.ou.debm.common.antlr.LLVMIRLexer;
 import nl.ou.debm.common.antlr.LLVMIRParser;
 import nl.ou.debm.common.feature1.LoopAssessor;
-import nl.ou.debm.common.feature2.DataStructuresFeature;
-import nl.ou.debm.common.feature3.CVisitor;
 import nl.ou.debm.common.feature3.FunctionAssessor;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
-import org.antlr.v4.runtime.TokenSource;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.HashMap;
 
 import static nl.ou.debm.common.IOElements.*;
 

--- a/src/main/java/nl/ou/debm/common/feature1/LoopProducer.java
+++ b/src/main/java/nl/ou/debm/common/feature1/LoopProducer.java
@@ -208,7 +208,7 @@ public class LoopProducer implements IFeature, IStatementGenerator  {
         if (loopInfo.bGetELC_UseReturn()){                      // add return if needed
             if (f.getType().bIsPrimitive()) {
                 // for any primitive, we can rely on the default value based on the type
-                list.add(STRINDENT + "if (getchar()==31) {return " + f.getType().strDefaultValue() + ";}");
+                list.add(STRINDENT + "if (getchar()==31) {return " + f.getType().strDefaultValue(m_cgenerator.structsByName) + ";}");
             }
             else{
                 // for any non-primitive, we must instantiate a return struct

--- a/src/main/java/nl/ou/debm/common/feature3/FunctionProducer.java
+++ b/src/main/java/nl/ou/debm/common/feature3/FunctionProducer.java
@@ -33,7 +33,7 @@ public class FunctionProducer implements IFeature, IExpressionGenerator, IFuncti
     @Override
     public String getNewExpression(int currentDepth, DataType type, boolean terminating) {
         if(terminating || Math.random() < 0.3){
-            return type.strDefaultValue();
+            return type.strDefaultValue(generator.structsByName);
         }else{
             return getFunctionCall(currentDepth + 1, type, null);
         }

--- a/src/main/java/nl/ou/debm/producer/CGenerator.java
+++ b/src/main/java/nl/ou/debm/producer/CGenerator.java
@@ -32,6 +32,7 @@ public class CGenerator {
     public List<Function> functions = new ArrayList<>();        // Store functions in list, to maintain their creation order
     public HashMap<DataType, List<Variable>> globalsByType = new HashMap<>();   // store global variables
     public List<Struct> structs = new ArrayList<>();            // store structs
+    public HashMap<String, Struct> structsByName = new HashMap<>(); // store structs by name
     public final DataType[] rawDataTypes = new DataType[6];     // table of basic data types
     private Function mainFunction;                              // main function
     private long lngNextGlobalLabel = 0;                        // index for next requested global label name
@@ -320,8 +321,8 @@ public class CGenerator {
     }
 
     /**
-     * Generate a source file at the specified location.
-     * @param path   Full path and file name of the output file
+     * Generate C-source code
+     * @return  Source code as a string
      * @throws Exception
      */
     public String generateSourceFile() throws Exception {
@@ -348,16 +349,17 @@ public class CGenerator {
                 allIncludes.addAll(includes);
         }
         for(var include : allIncludes.stream().distinct().toList())
-            sb.append("#include " + include + System.lineSeparator());
+            sb.append("#include ").append(include).append(System.lineSeparator());
 
         //Prevent warnings of unused values for compiler
-        sb.append("#pragma clang diagnostic ignored \"-Wunused-value\"" + System.lineSeparator());
+        sb.append("#pragma clang diagnostic ignored \"-Wunused-value\"").append(System.lineSeparator());
         // start with data structures
         writeStructs();
         // continue with globals, as they may use data structures
         writeGlobalVariables();
         // end with all the functions, as they may both use globals and data structures //todo ware het niet dat globale variabelen ook functies kunnen gebruiken. Leidt dat tot een probleem? Vast niet, maar dan doen we hier dus de aanname dat globale variabelen niet met een functieaanroep worden geïnitialiseerd.
         writeFunctions();
+        // return code as string
         return sb.toString();
     }
 
@@ -474,6 +476,8 @@ public class CGenerator {
                     newStruct.prefixName(currentFeature.getPrefix());
                     // add struct to array of structs
                     structs.add(newStruct);
+                    // add struct to map of structs
+                    structsByName.put(newStruct.name, newStruct);
                     // and return the result
                     return newStruct;
                 }

--- a/src/main/java/nl/ou/debm/test/GeneratorTest.java
+++ b/src/main/java/nl/ou/debm/test/GeneratorTest.java
@@ -1,7 +1,11 @@
 package nl.ou.debm.test;
 
 import nl.ou.debm.common.*;
+import nl.ou.debm.common.antlr.*;
 import nl.ou.debm.producer.CGenerator;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
@@ -11,20 +15,20 @@ import java.util.ArrayList;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 public class GeneratorTest {
 
     @Test
     void GetOneBinaryDone() throws Exception
     {
-        final var amountOfContainers = 1;
-        final var amountOfSources = 1;
-
         //1. Initialize folder structure
         var containersFolder = new File(Environment.containerBasePath);
         if (!containersFolder.exists() && !containersFolder.mkdirs())
             throw new Exception("Unable to create containers folder");
 
-        for (var containerIndex = 0; containerIndex < amountOfContainers; containerIndex++) {
+        //for (var containerIndex = 0; containerIndex < amountOfContainers; containerIndex++) {
+        { int containerIndex = 0;
             //2. Make package folder structure
             var containerFolderPath = IOElements.strContainerFullPath(containerIndex);
             var containerFolder = new File(containerFolderPath);
@@ -34,7 +38,8 @@ public class GeneratorTest {
             //3. Generate C-sources
             var EXEC = Executors.newCachedThreadPool();
             var tasks = new ArrayList<Callable<String>>();
-            for (var testIndex = 0; testIndex < amountOfSources; testIndex++) {
+            //for (var testIndex = 0; testIndex < amountOfSources; testIndex++) {
+            { int testIndex = 999;
                 var testFolderPath = IOElements.strTestFullPath(containerIndex, testIndex);
                 var testFolder = new File(testFolderPath);
                 if (!testFolder.exists() && !testFolder.mkdirs())
@@ -97,9 +102,21 @@ public class GeneratorTest {
                     break;
                 }
                 var results = EXEC.invokeAll(tasks);
-                break;
-            }
 
+                /////////// check c-code in parser
+
+                var lexer = new CLexer(CharStreams.fromFileName(sourceFilePath));
+                var parser = new CParser(new CommonTokenStream(lexer));
+
+                var walker = new ParseTreeWalker();
+                var listener = new CBaseListener();
+
+                System.out.println("Walking...");
+
+                assertDoesNotThrow(() -> walker.walk(listener, parser.compilationUnit()));
+
+                //break;
+            }
         }
     }
 }


### PR DESCRIPTION
**In short**
Default values for structures needed recoding, because the compiler could cope, but ANTLR refused.

**Problem**
Consider this code:
```
struct S1{
int a;
}
struct S2{
struct S1 a;
}
...
return (struct S2){};
```
The compiler accepted this, but ANTLR wouldn't. It wants an init like this:
`return (struct S2){(struct S1){23}};`

**Measures taken**
- The generator stores structs not only in a list, but also in a map, so they can be searched by name;
- This map must be passed when asking DataType for a default value;
- The method recursively adds the init-sequence, breaking the recursion every time it ends up adding a primitive's value.

**Misc**
Some minor changes (such as replacing a sb.append(... + ...) with sb.append().append() as recommended by Intellij).

**PS**
I stand corrected. I first thought the default value-problems came from Reijer's code, but it seems it was strGetDefaultValue that caused the problem and I think I was the one writing that... _Mea culpa..._