### PR TITLE
Adjust statement trimming

### DIFF
--- a/src/main/java/nl/ou/debm/common/Misc.java
+++ b/src/main/java/nl/ou/debm/common/Misc.java
@@ -1,11 +1,12 @@
 package nl.ou.debm.common;
 
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
 import java.util.Random;
 
 import static java.lang.Math.abs;
-import static java.lang.Math.max;
 
 /**
  * Class containing all kinds of miscellaneous functions
@@ -72,4 +73,23 @@ public class Misc {
     // make one single project wide random generator available
     public static final Random rnd = new Random();
 
+    /**
+     * Remove white space from right side of string
+     * @param strInput string to be stripped
+     * @return  string without trailing whitespace, may be null if input is null
+     */
+    public static String strTrimRight(String strInput){
+        // check input
+        if (strInput == null){
+            return null;
+        }
+        // remove trailing whitespace
+        int p;
+        for (p=strInput.length()-1; p>=0; --p){
+            if (!Character.isWhitespace(strInput.charAt(p))){
+                break;
+            }
+        }
+        return strInput.substring(0, p+1);
+    }
 }

--- a/src/main/java/nl/ou/debm/common/feature1/LoopProducer.java
+++ b/src/main/java/nl/ou/debm/common/feature1/LoopProducer.java
@@ -51,7 +51,7 @@ public class LoopProducer implements IFeature, IStatementGenerator  {
     ///////////////////
     private final StatementPrefs m_dummyPrefs = new StatementPrefs(null);
     private final StatementPrefs m_defaultEmptyPrefs = new StatementPrefs(null);
-    private final static String STRINDENT = "  ";
+    private final static String STRINDENT = "\t";
 
     // object attributes
     ////////////////////

--- a/src/main/java/nl/ou/debm/producer/Function.java
+++ b/src/main/java/nl/ou/debm/producer/Function.java
@@ -3,6 +3,8 @@ package nl.ou.debm.producer;
 import java.util.ArrayList;
 import java.util.List;
 
+import static nl.ou.debm.common.Misc.strTrimRight;
+
 public class Function {
 
     private static long lngFunctionCounter = 0;     // keep track of the number of created functions for autoname
@@ -128,7 +130,7 @@ public class Function {
      * @param statement     String representing the statement to be added.
      */
     public void addStatement(String statement){
-        statements.add(statement.trim());
+        statements.add(strTrimRight(statement));
     }
 
     /**
@@ -137,7 +139,7 @@ public class Function {
      */
     public void addStatements(List<String> newStatements) {
         for (var statement : newStatements) {
-            statements.add(statement.trim());
+            statements.add(strTrimRight(statement));
         }
     }
 

--- a/src/main/java/nl/ou/debm/test/GeneratorTest.java
+++ b/src/main/java/nl/ou/debm/test/GeneratorTest.java
@@ -39,7 +39,7 @@ public class GeneratorTest {
             var EXEC = Executors.newCachedThreadPool();
             var tasks = new ArrayList<Callable<String>>();
             //for (var testIndex = 0; testIndex < amountOfSources; testIndex++) {
-            { int testIndex = 999;
+            { int testIndex = 0;
                 var testFolderPath = IOElements.strTestFullPath(containerIndex, testIndex);
                 var testFolder = new File(testFolderPath);
                 if (!testFolder.exists() && !testFolder.mkdirs())

--- a/src/main/java/nl/ou/debm/test/MiscTest.java
+++ b/src/main/java/nl/ou/debm/test/MiscTest.java
@@ -5,8 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
-import static nl.ou.debm.common.Misc.cBooleanToChar;
-import static nl.ou.debm.common.Misc.strGetNumberWithPrefixZeros;
+import static nl.ou.debm.common.Misc.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 class MiscTest {
@@ -101,7 +100,34 @@ class MiscTest {
     }
 
     @Test
-    void getMeAnyGUID(){
-        System.out.println(UUID.randomUUID());
+    void testTrimRight(){
+        for (int i=0; i<10000; i++){
+            var v1 = strGetWhiteSpace();
+            var v2 = strGetNonWhiteSpace();
+            var v3 = strGetWhiteSpace();
+
+            if (v2.isEmpty()){
+                assertEquals("", strTrimRight(v1 + v2 + v3));
+            }
+            else{
+                assertEquals(v1 + v2, strTrimRight(v1 + v2 + v3));
+            }
+        }
+    }
+
+    private String strGetWhiteSpace() {
+        var sb = new StringBuilder();
+        for (int i=rnd.nextInt(0,10); i>0; --i){
+            while (true){
+                char c = (char)rnd.nextInt(0,256);
+                if (Character.isWhitespace(c)){
+                    sb.append(c); break;
+                }
+            }
+        }
+        return sb.toString();
+    }
+    private String strGetNonWhiteSpace(){
+        return UUID.randomUUID().toString().substring(0, Misc.rnd.nextInt(0,10));
     }
 }


### PR DESCRIPTION
**Main**
This PR introduces a new String strTrimRight(String) function. This only removes trailing whitespace and leaves header whitespace untouched.
**Why**
The loop producer produces indented code, which was un-indented by the function that adds code to functions, making the resulting source code less human readable.
**Misc**
Appropriate test routine added.
Removed a test that wasn't really a test (UUID).
Reset the target container for one-test-only-test to 0 in stead of 999.