### PR TITLE
Unrolled loops

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ANTLRGenerationPreferences">
     <option name="perGrammarGenerationSettings">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -57,7 +57,7 @@
     </option>
   </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_20" default="true" project-jdk-name="18" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_18" default="true" project-jdk-name="18" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/main/java/nl/ou/debm/common/feature1/ELoopUnrollTypes.java
+++ b/src/main/java/nl/ou/debm/common/feature1/ELoopUnrollTypes.java
@@ -1,0 +1,33 @@
+package nl.ou.debm.common.feature1;
+
+public enum ELoopUnrollTypes {
+    NO_ATTEMPT,
+    ATTEMPT_PRINT_LOOP_VAR,
+    ATTEMPT_DO_NOT_PRINT_LOOP_VAR;
+
+    public String strPropertyValue(){
+        String out;
+        switch (this){
+            case ATTEMPT_PRINT_LOOP_VAR ->          out =  "U+" ;
+            case ATTEMPT_DO_NOT_PRINT_LOOP_VAR ->   out = "U-" ;
+            default ->                              out =  "NU" ;
+        }
+        return out;
+    }
+
+    public static ELoopUnrollTypes stringToType(String strIn){
+        ELoopUnrollTypes out = NO_ATTEMPT;
+        try {
+            out = ELoopUnrollTypes.valueOf(strIn);
+        }
+        catch (Exception e){
+            for (var item : ELoopUnrollTypes.values()){
+                if (strIn.equals(item.toString())){
+                    out = item;
+                    break;
+                }
+            }
+        }
+        return out;
+    }
+}

--- a/src/main/java/nl/ou/debm/common/feature1/ELoopVarUpdateTypes.java
+++ b/src/main/java/nl/ou/debm/common/feature1/ELoopVarUpdateTypes.java
@@ -31,6 +31,18 @@ public enum ELoopVarUpdateTypes {
         return out;
     }
 
+    /**
+     * Use this update type for loops that we want to compiler to unroll?
+     * @return true when this update type is ++ -- += or -=
+     */
+    public boolean bIncludeForUnrolling(){
+        boolean out = false;
+        switch (this) {
+            case INCREASE_BY_ONE, DECREASE_BY_ONE, INCREASE_OTHER, DECREASE_OTHER -> out = true;
+        }
+        return out;
+    }
+
     public String strPropertyValue(){
         return strShortCode();
     }

--- a/src/main/java/nl/ou/debm/common/feature1/ELoopVarUpdateTypes.java
+++ b/src/main/java/nl/ou/debm/common/feature1/ELoopVarUpdateTypes.java
@@ -75,6 +75,18 @@ public enum ELoopVarUpdateTypes {
         return out;
     }
 
+    public String strGetUpdateExpressionForUnrolling(ELoopVarTypes vt, int iUpdateValue){
+        String out = "";
+        switch (this){
+            case INCREASE_BY_ONE ->   out = "++";
+            case DECREASE_BY_ONE ->   out = "--";
+            case INCREASE_OTHER ->    out = "+=" + iUpdateValue + strFloatTrailer(vt == ELoopVarTypes.FLOAT);
+            case DECREASE_OTHER ->    out = "-=" + iUpdateValue + strFloatTrailer(vt == ELoopVarTypes.FLOAT);
+            default -> { assert false; }
+        }
+        return out;
+    }
+
     public static ELoopVarUpdateTypes intToType(int i){
         return switch (i) {
             case 1 ->       DECREASE_BY_ONE;

--- a/src/main/java/nl/ou/debm/common/feature1/LoopCodeMarker.java
+++ b/src/main/java/nl/ou/debm/common/feature1/LoopCodeMarker.java
@@ -22,6 +22,7 @@ public class LoopCodeMarker extends CodeMarker {
     private final static String STRTESTEXPRESSION="TSEXP";              // field name for test expression
     private final static String STRLOOPVARNAME="LVN";                   // field name for loop variable name
     private final static String STRLOOPVARTYPE="LVT";                   // field name for loop variable type
+    private final static String STRATTEMPTUNROLLING = "UNR";            // field name for loop unrolling attempt
 
     /**
      * Default constructor
@@ -158,6 +159,12 @@ public class LoopCodeMarker extends CodeMarker {
     }
     public String strGetLoopVarName(){
         return strPropertyValue(STRLOOPVARNAME);
+    }
+    public void setAttemptLoopUnrolling(boolean bValue){
+        addBooleanToCodeMarker(STRATTEMPTUNROLLING, bValue);
+    }
+    public boolean bGetAttemptLoopUnrolling(){
+        return Misc.bIsTrue(strPropertyValue(STRATTEMPTUNROLLING));
     }
     /**
      * Process a binary value for adding to CM object. If binary is TRUE, the

--- a/src/main/java/nl/ou/debm/common/feature1/LoopCodeMarker.java
+++ b/src/main/java/nl/ou/debm/common/feature1/LoopCodeMarker.java
@@ -160,11 +160,11 @@ public class LoopCodeMarker extends CodeMarker {
     public String strGetLoopVarName(){
         return strPropertyValue(STRLOOPVARNAME);
     }
-    public void setAttemptLoopUnrolling(boolean bValue){
-        addBooleanToCodeMarker(STRATTEMPTUNROLLING, bValue);
+    public void setLoopUnrolling(ELoopUnrollTypes bValue){
+        setProperty(STRATTEMPTUNROLLING, bValue.strPropertyValue());
     }
-    public boolean bGetAttemptLoopUnrolling(){
-        return Misc.bIsTrue(strPropertyValue(STRATTEMPTUNROLLING));
+    public ELoopUnrollTypes getLoopUnrolling(){
+        return ELoopUnrollTypes.stringToType(strPropertyValue(STRATTEMPTUNROLLING));
     }
     /**
      * Process a binary value for adding to CM object. If binary is TRUE, the

--- a/src/main/java/nl/ou/debm/common/feature1/LoopInfo.java
+++ b/src/main/java/nl/ou/debm/common/feature1/LoopInfo.java
@@ -36,29 +36,63 @@ public class LoopInfo {
     private static final List<LoopInfo> s_loopRepo = new ArrayList<>();   // repository containing all loops that need to be implemented
     private static final ELoopCommands s_defaultLoopCommand = ELoopCommands.FOR;  // default loop command
 
+    // class init
+    // ----------
+    static {
+        /*
+         * First distinguish between cases WITH loop variables and WITHOUT them
+         *
+         * cases WITHOUT loop variables can differ in command (3), and any combination
+         * of internal of external loop commands (2^3 * 2^6 = 512).
+         * As there is no loop var testing, it should not make the slightest difference
+         * whether for, do or while is used.
+         * Therefore, we choose to implement these 512 loops and use for/do/dowhile-
+         * commands randomly.
+         *
+         * cases WITH loop variables are harder, because there are so many different
+         * possibilities. We use orthogonal arrays to make the lot containable.
+         *
+         * then there is the set of loops that we try to lure the compiler into unrolling
+         * these will never use any internal or external control flow constructs
+         * and they will only use static updates (no +=getchar() or -=getchar)
+         */
+
+        // part 1: without loop vars
+        initLoopRepo_PartWithoutLoopVars();
+
+        // part 2: with loop vars
+        initLoopRepo_PartWithLoopVars();
+
+        // part 3: unroll loops
+        initLoopRepo_PartForUnrolling();
+
+        // create variable expressions
+        makeLoopVarExpressions();
+    }
 
     // object attributes
     // -----------------
     //
     // part A: all information required to make the loop statements
     // basics
-    private ELoopCommands m_loopCommand = s_defaultLoopCommand;// do/for/while
-    private LoopVariable m_loopVar = null;                     // loop variable details (null = unused)
+    private ELoopCommands m_loopCommand = s_defaultLoopCommand;     // do/for/while
+    private LoopVariable m_loopVar = null;                          // loop variable details (null = unused)
     // internal loop flow control
-    private boolean m_bILC_UseContinue = false;             // put continue statement in loop
-    private boolean m_bILC_UseGotoBegin = false;            // put goto begin in loop
-    private boolean m_bILC_UseGotoEnd = false;              // put goto end in loop
+    private boolean m_bILC_UseContinue = false;                     // put continue statement in loop
+    private boolean m_bILC_UseGotoBegin = false;                    // put goto begin in loop
+    private boolean m_bILC_UseGotoEnd = false;                      // put goto end in loop
     // external loop flow control
-    private boolean m_bELC_UseBreak = false;                // put break statement in loop
-    private boolean m_bELC_UseExit = false;                 // put exit call in loop
-    private boolean m_bELC_UseReturn = false;                      // put return statement in loop
-    private boolean m_bELC_UseGotoDirectlyAfterThisLoop = false;   // put goto next-statement-after-loop in loop
-    private boolean m_bELC_UseGotoFurtherFromThisLoop = false;     // goto somewhere further than immediately after loop
-    private boolean m_bELC_BreakOutNestedLoops = false;            // break out nested loops
+    private boolean m_bELC_UseBreak = false;                        // put break statement in loop
+    private boolean m_bELC_UseExit = false;                         // put exit call in loop
+    private boolean m_bELC_UseReturn = false;                       // put return statement in loop
+    private boolean m_bELC_UseGotoDirectlyAfterThisLoop = false;    // put goto next-statement-after-loop in loop
+    private boolean m_bELC_UseGotoFurtherFromThisLoop = false;      // goto somewhere further than immediately after loop
+    private boolean m_bELC_BreakOutNestedLoops = false;             // break out nested loops
     // part B: all information for loop objects
-    private long m_lngLoopID = 0;                        // unique loop-object ID
-    private int m_iNumberOfImplementations = 0;               // number of times this loop is actually in the code
+    private long m_lngLoopID = 0;                                   // unique loop-object ID
+    private int m_iNumberOfImplementations = 0;                     // number of times this loop is actually in the code
     private String m_strVariablePrefix = "";                        // prefix for this loop's variable
+    private boolean m_bAttemptUnrolling = false;                    // if true, try to produce a loop likely to be unrolled
 
     // class access
     // ------------
@@ -76,8 +110,6 @@ public class LoopInfo {
      * @param bShuffle  shuffle repo after copy
      */
     public static void FillLoopRepo(List<LoopInfo> destRepo, boolean bShuffle){
-        // init repository
-        InitLoopRepo();
         // make deep copy
         destRepo.clear();
         for (var li : s_loopRepo){
@@ -86,152 +118,6 @@ public class LoopInfo {
         // shuffle?
         if (bShuffle){
             Collections.shuffle(destRepo);
-        }
-    }
-
-    /**
-     * Fill internal loop repository
-     */
-    private static void InitLoopRepo() {
-        // init only when necessary
-        if (!s_loopRepo.isEmpty()) {
-            return;
-        }
-
-        /*
-        * First distinguish between cases WITH loop variables and WITHOUT them
-        * 
-        * cases WITHOUT loop variables can differ in command (3), and any combination
-        * of internal of external loop commands (2^3 * 2^6 = 512).
-        * As there is no loop var testing, it should not make the slightest difference
-        * whether for, do or while is used.
-        * Therefore, we choose to implement these 512 loops and use for/do/dowhile-
-        * commands randomly.
-        * 
-        * cases WITH loop variables are harder, because there are so many different
-        * possibilities. We use orthogonal arrays to make the lot containable.
-        * 
-        */
-        
-        // part 1: without loop vars
-        InitLoopRepo_PartWithoutLoopVars();
-
-        // part 2: with loop vars
-        InitLoopRepo_PartWithLoopVars();
-
-        // create variable expressions
-        makeLoopVarExpressions();
-    }
-    
-    private static void InitLoopRepo_PartWithoutLoopVars(){
-        // make all different combinations and add them to the repo
-        for (int c=0; c<512; ++c){
-            var loop = new LoopInfo();
-            loop.m_bILC_UseContinue = ((c & 1) > 0);
-            loop.m_bILC_UseGotoBegin = ((c & 2) > 0);
-            loop.m_bILC_UseGotoEnd = ((c & 4) > 0);
-            loop.m_bELC_UseBreak = ((c & 8) > 0);
-            loop.m_bELC_UseExit = ((c & 16) > 0);
-            loop.m_bELC_UseReturn = ((c & 32) > 0);
-            loop.m_bELC_UseGotoDirectlyAfterThisLoop = ((c & 64) > 0);
-            loop.m_bELC_UseGotoFurtherFromThisLoop = ((c & 128) > 0);
-            loop.m_bELC_BreakOutNestedLoops = ((c & 256) > 0);
-            s_loopRepo.add(loop);
-        }
-        // distribute for/do/dowhile rather randomly
-        // first, make about 1/3 while loops
-        for (int n=0; n< (s_loopRepo.size()/3); ++n){
-            do{
-                var loop = s_loopRepo.get(Misc.rnd.nextInt(0, s_loopRepo.size()));
-                if (loop.m_loopCommand == s_defaultLoopCommand){
-                    loop.m_loopCommand = ELoopCommands.WHILE;
-                    break;
-                }
-            } while (true);
-        }
-        // then, make about 1/3 do-while
-        for (int n=0; n< (s_loopRepo.size()/3); ++n){
-            do{
-                var loop = s_loopRepo.get(Misc.rnd.nextInt(0, s_loopRepo.size()));
-                if (loop.m_loopCommand == s_defaultLoopCommand){
-                    loop.m_loopCommand = ELoopCommands.DOWHILE;
-                    break;
-                }
-            } while (true);
-        }
-    }
-
-    private static void InitLoopRepo_PartWithLoopVars(){
-        // use orthogonal arrays
-        // factors: 8 update dir/type
-        //          4 loop var test
-        //     (9x) 2 control flow setting
-        //          2 var type
-
-        // get orthogonal array
-        final int [] LEVELS = {8, 4, 2, 2,2,2, 2,2,2, 2,2,2};
-        final int RUNS = 32;
-        final int STRENGTH = 2;
-        OrthogonalArray oa;
-        try {
-            oa = new OrthogonalArray(LEVELS, RUNS, STRENGTH);
-        }
-        catch (Exception e){
-            System.out.println("Problem with orthogonal array: " + e);
-            return;
-        }
-
-        final int COL_UPDATE = 0;
-        final int COL_TEST = 1;
-        final int COL_VAR_TYPE = 2;
-        final int COL_CONTINUE = 3;
-        final int COL_GOTO_I1 = 4;
-        final int COL_GOTO_I2 = 5;
-        final int COL_BREAK = 6;
-        final int COL_EXIT = 7;
-        final int COL_RETURN = 8;
-        final int COL_GOTO_E1 = 9;
-        final int COL_GOTO_E2 = 10;
-        final int COL_GOTO_E3 = 11;
-
-        // the big setup-loop
-        for (int run=0; run < oa.iNRuns() ; ++run){
-            // setup new loop and shorthand for loop var object
-            var loop = new LoopInfo();
-            loop.m_loopVar = new LoopVariable();
-            var lv = loop.m_loopVar;
-            // set several loop variable type
-            switch (oa.iValuePerRunPerColumn(run, COL_VAR_TYPE)){
-                case 0 -> lv.eVarType = ELoopVarTypes.INT;
-                case 1 -> lv.eVarType = ELoopVarTypes.FLOAT;
-            }
-            // set update method
-            lv.eUpdateType = ELoopVarUpdateTypes.intToType(oa.iValuePerRunPerColumn(run, COL_UPDATE));
-
-            // set test method
-            lv.eTestType = ELoopVarTestTypes.intToType(oa.iValuePerRunPerColumn(run, COL_TEST), lv.eUpdateType);
-
-            // set control flow properties
-            loop.m_bILC_UseContinue =                   (oa.iValuePerRunPerColumn(run, COL_CONTINUE) == 1);
-            loop.m_bILC_UseGotoBegin =                  (oa.iValuePerRunPerColumn(run, COL_GOTO_I1) == 1);
-            loop.m_bILC_UseGotoEnd =                    (oa.iValuePerRunPerColumn(run, COL_GOTO_I2) == 1);
-            loop.m_bELC_UseBreak =                      (oa.iValuePerRunPerColumn(run, COL_BREAK) == 1);
-            loop.m_bELC_UseExit =                       (oa.iValuePerRunPerColumn(run, COL_EXIT) == 1);
-            loop.m_bELC_UseReturn =                     (oa.iValuePerRunPerColumn(run, COL_RETURN) == 1);
-            loop.m_bELC_UseGotoDirectlyAfterThisLoop =  (oa.iValuePerRunPerColumn(run, COL_GOTO_E1) == 1);
-            loop.m_bELC_UseGotoFurtherFromThisLoop =    (oa.iValuePerRunPerColumn(run, COL_GOTO_E2) == 1);
-            loop.m_bELC_BreakOutNestedLoops =           (oa.iValuePerRunPerColumn(run, COL_GOTO_E3) == 1);
-            
-
-            // add loop to repo
-            s_loopRepo.add(loop);
-            // and also add other loop types (not that many, so we can combine everything with everything)
-            loop = new LoopInfo(loop);
-            loop.m_loopCommand = ELoopCommands.WHILE;
-            s_loopRepo.add(loop);
-            loop = new LoopInfo(loop);
-            loop.m_loopCommand = ELoopCommands.DOWHILE;
-            s_loopRepo.add(loop);
         }
     }
 
@@ -267,6 +153,7 @@ public class LoopInfo {
             }
             m_iNumberOfImplementations = rhs.m_iNumberOfImplementations;
             m_strVariablePrefix = rhs.m_strVariablePrefix;
+            m_bAttemptUnrolling = rhs.m_bAttemptUnrolling;
         }
 
         // always create new ID
@@ -296,6 +183,7 @@ public class LoopInfo {
         m_bELC_UseGotoFurtherFromThisLoop = cm.bGetUseGotoFurtherFromThisLoop();
         m_bELC_BreakOutNestedLoops = cm.bGetUseBreakOutNestedLoops();
         m_lngLoopID = cm.lngGetLoopID();
+        m_bAttemptUnrolling = cm.bGetAttemptLoopUnrolling();
     }
 
     /**
@@ -344,6 +232,9 @@ public class LoopInfo {
     }
     public ELoopCommands getLoopCommand() {
         return m_loopCommand;
+    }
+    public boolean bGetAttemptUnrolling(){
+        return m_bAttemptUnrolling;
     }
     public void setVariablePrefix(String strPrefix){
         m_strVariablePrefix = strPrefix;
@@ -556,6 +447,9 @@ public class LoopInfo {
         out.setUseGotoDirectlyAfterLoop(  m_bELC_UseGotoDirectlyAfterThisLoop);
         out.setUseGotoFurtherFromThisLoop(m_bELC_UseGotoFurtherFromThisLoop);
         out.setUseBreakOutNestedLoops(    m_bELC_BreakOutNestedLoops);
+        // unrolling attempt
+        out.setAttemptLoopUnrolling(m_bAttemptUnrolling);
+        // done
         return out;
     }
 
@@ -583,34 +477,222 @@ public class LoopInfo {
     /**
      * create loop variable expressions for every loop that has a loop variable
      */
+    /**
+     * add to the default loop repo loops that have no loop variables
+     */
+    private static void initLoopRepo_PartWithoutLoopVars(){
+        // make all different combinations and add them to the repo
+        for (int c=0; c<512; ++c){
+            var loop = new LoopInfo();
+            loop.m_bILC_UseContinue = ((c & 1) > 0);
+            loop.m_bILC_UseGotoBegin = ((c & 2) > 0);
+            loop.m_bILC_UseGotoEnd = ((c & 4) > 0);
+            loop.m_bELC_UseBreak = ((c & 8) > 0);
+            loop.m_bELC_UseExit = ((c & 16) > 0);
+            loop.m_bELC_UseReturn = ((c & 32) > 0);
+            loop.m_bELC_UseGotoDirectlyAfterThisLoop = ((c & 64) > 0);
+            loop.m_bELC_UseGotoFurtherFromThisLoop = ((c & 128) > 0);
+            loop.m_bELC_BreakOutNestedLoops = ((c & 256) > 0);
+            s_loopRepo.add(loop);
+        }
+        // distribute for/do/dowhile rather randomly
+        // first, make about 1/3 while loops
+        for (int n=0; n< (s_loopRepo.size()/3); ++n){
+            do{
+                var loop = s_loopRepo.get(Misc.rnd.nextInt(0, s_loopRepo.size()));
+                if (loop.m_loopCommand == s_defaultLoopCommand){
+                    loop.m_loopCommand = ELoopCommands.WHILE;
+                    break;
+                }
+            } while (true);
+        }
+        // then, make about 1/3 do-while
+        for (int n=0; n< (s_loopRepo.size()/3); ++n){
+            do{
+                var loop = s_loopRepo.get(Misc.rnd.nextInt(0, s_loopRepo.size()));
+                if (loop.m_loopCommand == s_defaultLoopCommand){
+                    loop.m_loopCommand = ELoopCommands.DOWHILE;
+                    break;
+                }
+            } while (true);
+        }
+    }
+
+    /**
+     * add to the internal loop repo ordinary loops that have loop variables
+     */
+    private static void initLoopRepo_PartWithLoopVars(){
+        // use orthogonal arrays
+        // factors: 8 update dir/type
+        //          4 loop var test
+        //     (9x) 2 control flow setting
+        //          2 var type
+
+        // get orthogonal array
+        final int [] LEVELS = {8, 4, 2, 2,2,2, 2,2,2, 2,2,2};
+        final int RUNS = 32;
+        final int STRENGTH = 2;
+        OrthogonalArray oa;
+        try {
+            oa = new OrthogonalArray(LEVELS, RUNS, STRENGTH);
+        }
+        catch (Exception e){
+            System.out.println("Problem with orthogonal array: " + e);
+            return;
+        }
+
+        final int COL_UPDATE = 0;
+        final int COL_TEST = 1;
+        final int COL_VAR_TYPE = 2;
+        final int COL_CONTINUE = 3;
+        final int COL_GOTO_I1 = 4;
+        final int COL_GOTO_I2 = 5;
+        final int COL_BREAK = 6;
+        final int COL_EXIT = 7;
+        final int COL_RETURN = 8;
+        final int COL_GOTO_E1 = 9;
+        final int COL_GOTO_E2 = 10;
+        final int COL_GOTO_E3 = 11;
+
+        // the big setup-loop
+        for (int run=0; run < oa.iNRuns() ; ++run){
+            // setup new loop and shorthand for loop var object
+            var loop = new LoopInfo();
+            loop.m_loopVar = new LoopVariable();
+            var lv = loop.m_loopVar;
+            // set several loop variable type
+            switch (oa.iValuePerRunPerColumn(run, COL_VAR_TYPE)){
+                case 0 -> lv.eVarType = ELoopVarTypes.INT;
+                case 1 -> lv.eVarType = ELoopVarTypes.FLOAT;
+            }
+            // set update method
+            lv.eUpdateType = ELoopVarUpdateTypes.intToType(oa.iValuePerRunPerColumn(run, COL_UPDATE));
+
+            // set test method
+            lv.eTestType = ELoopVarTestTypes.intToType(oa.iValuePerRunPerColumn(run, COL_TEST), lv.eUpdateType);
+
+            // set control flow properties
+            loop.m_bILC_UseContinue =                   (oa.iValuePerRunPerColumn(run, COL_CONTINUE) == 1);
+            loop.m_bILC_UseGotoBegin =                  (oa.iValuePerRunPerColumn(run, COL_GOTO_I1) == 1);
+            loop.m_bILC_UseGotoEnd =                    (oa.iValuePerRunPerColumn(run, COL_GOTO_I2) == 1);
+            loop.m_bELC_UseBreak =                      (oa.iValuePerRunPerColumn(run, COL_BREAK) == 1);
+            loop.m_bELC_UseExit =                       (oa.iValuePerRunPerColumn(run, COL_EXIT) == 1);
+            loop.m_bELC_UseReturn =                     (oa.iValuePerRunPerColumn(run, COL_RETURN) == 1);
+            loop.m_bELC_UseGotoDirectlyAfterThisLoop =  (oa.iValuePerRunPerColumn(run, COL_GOTO_E1) == 1);
+            loop.m_bELC_UseGotoFurtherFromThisLoop =    (oa.iValuePerRunPerColumn(run, COL_GOTO_E2) == 1);
+            loop.m_bELC_BreakOutNestedLoops =           (oa.iValuePerRunPerColumn(run, COL_GOTO_E3) == 1);
+
+
+            // add loop to repo
+            s_loopRepo.add(loop);
+            // and also add other loop types (not that many, so we can combine everything with everything)
+            loop = new LoopInfo(loop);
+            loop.m_loopCommand = ELoopCommands.WHILE;
+            s_loopRepo.add(loop);
+            loop = new LoopInfo(loop);
+            loop.m_loopCommand = ELoopCommands.DOWHILE;
+            s_loopRepo.add(loop);
+        }
+    }
+
+    /**
+     * add to internal loop repo loops that will quite probably unroll
+     */
+    private static void initLoopRepo_PartForUnrolling(){
+        // unrolling
+        // 3 loop commands (for, do while)
+        // 4 dir/types (++ -- +=c -=c)
+        // 2 var types (int float)
+        // 3 tests (!=, < or <= when increasing; always test)
+        // 0 control flow settings
+        // total: 4*2*3*3=72 combinations
+        // not that many, we add them all
+
+        for (var updateItem : ELoopVarUpdateTypes.values()) {
+            if (updateItem.bIncludeForUnrolling()) {
+                for (var loopCommand : ELoopCommands.values()) {
+                    for (var varTypeItem : ELoopVarTypes.values()) {
+                        // init loop info
+                        var loop = new LoopInfo();
+                        loop.m_loopVar = new LoopVariable();
+                        var lv = loop.m_loopVar;
+                        // set easy values
+                        loop.m_bAttemptUnrolling = true;
+                        loop.m_loopCommand = loopCommand;
+                        lv.eVarType = varTypeItem;
+                        lv.eUpdateType = updateItem;
+                        // test types:
+                        // 1.: !=
+                        lv.eTestType = ELoopVarTestTypes.NON_EQUAL;
+                        s_loopRepo.add(loop);
+                        // 2., 3.: < and <=
+                        if (lv.eUpdateType.bIsIncreasing()){
+                            loop = new LoopInfo(loop);
+                            loop.m_loopVar.eTestType = ELoopVarTestTypes.SMALLER_THAN;
+                            s_loopRepo.add(loop);
+                            loop = new LoopInfo(loop);
+                            loop.m_loopVar.eTestType = ELoopVarTestTypes.SMALLER_OR_EQUAL;
+                            s_loopRepo.add(loop);
+                        }
+                        // 4., 5.: > and >=
+                        else{
+                            loop = new LoopInfo(loop);
+                            loop.m_loopVar.eTestType = ELoopVarTestTypes.GREATER_THAN;
+                            s_loopRepo.add(loop);
+                            loop = new LoopInfo(loop);
+                            loop.m_loopVar.eTestType = ELoopVarTestTypes.GREATER_OR_EQUAL;
+                            s_loopRepo.add(loop);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     private static void makeLoopVarExpressions(){
         for (var loop : s_loopRepo) {
-            // init expression
-            if (loop.getLoopExpressions().bInitAvailable()){
-                // count low to high or high to low
-                int low = ILOOPVARLOWVALUELOWBOUND;
-                int high = ILOOPVARLOWVALUEHIGHBOUND;
-                if (loop.m_loopVar.eUpdateType.bIsDecreasing()){
-                    low = ILOOPVARHIGHVALUELOWBOUND;
-                    high = ILOOPVARHIGHVALUEHIGHBOUND;
-                }
-                // random init value
-                loop.m_loopVar.strInitExpression = Misc.rnd.nextInt(low, high) + strFloatTrailer(loop.m_loopVar.eVarType==ELoopVarTypes.FLOAT);
+            // depends on unrolling attempt
+            if (loop.bGetAttemptUnrolling()) {
+                // attempted loop unrolling
+                //
+                // this may only happen when all expressions are available
+                assert loop.getLoopExpressions().bInitAvailable();
+                assert loop.getLoopExpressions().bUpdateAvailable();
+                assert loop.getLoopExpressions().bTestAvailable();
+                //
+                // TODO: CONTINUE HERE
             }
-            if (loop.getLoopExpressions().bUpdateAvailable()){
-                // set update expression
-                loop.m_loopVar.strUpdateExpression = loop.m_loopVar.eUpdateType.strGetUpdateExpression(loop.m_loopVar.eVarType==ELoopVarTypes.FLOAT);
-            }
-            if (loop.getLoopExpressions().bTestAvailable()){
-                // only return test expression when wanted
-                int low = ILOOPVARHIGHVALUELOWBOUND;
-                int high = ILOOPVARHIGHVALUEHIGHBOUND;
-                if (loop.m_loopVar.eUpdateType.bIsDecreasing()){
-                    low = ILOOPVARLOWVALUELOWBOUND;
-                    high = ILOOPVARLOWVALUEHIGHBOUND;
+            else {
+                // normal loops
+                ///////////////
+
+                // init expression
+                if (loop.getLoopExpressions().bInitAvailable()) {
+                    // count low to high or high to low
+                    int low = ILOOPVARLOWVALUELOWBOUND;
+                    int high = ILOOPVARLOWVALUEHIGHBOUND;
+                    if (loop.m_loopVar.eUpdateType.bIsDecreasing()) {
+                        low = ILOOPVARHIGHVALUELOWBOUND;
+                        high = ILOOPVARHIGHVALUEHIGHBOUND;
+                    }
+                    // random init value
+                    loop.m_loopVar.strInitExpression = Misc.rnd.nextInt(low, high) + strFloatTrailer(loop.m_loopVar.eVarType == ELoopVarTypes.FLOAT);
                 }
-                // random test value, combine with operator
-                loop.m_loopVar.strTestExpression = loop.m_loopVar.eTestType.strCOperator() + Misc.rnd.nextInt(low,high);
+                if (loop.getLoopExpressions().bUpdateAvailable()) {
+                    // set update expression
+                    loop.m_loopVar.strUpdateExpression = loop.m_loopVar.eUpdateType.strGetUpdateExpression(loop.m_loopVar.eVarType == ELoopVarTypes.FLOAT);
+                }
+                if (loop.getLoopExpressions().bTestAvailable()) {
+                    // only return test expression when wanted
+                    int low = ILOOPVARHIGHVALUELOWBOUND;
+                    int high = ILOOPVARHIGHVALUEHIGHBOUND;
+                    if (loop.m_loopVar.eUpdateType.bIsDecreasing()) {
+                        low = ILOOPVARLOWVALUELOWBOUND;
+                        high = ILOOPVARLOWVALUEHIGHBOUND;
+                    }
+                    // random test value, combine with operator
+                    loop.m_loopVar.strTestExpression = loop.m_loopVar.eTestType.strCOperator() + Misc.rnd.nextInt(low, high);
+                }
             }
         }
     }
@@ -660,13 +742,19 @@ public class LoopInfo {
     ////////////////////////////////////////
 
     public static String strToStringHeader(){
-        return "I/F TYPE    IN UP TS  IC IB IE  EB EE ER ED EN EF  LV VT LU LT";
+        return "I/F TYPE    N/U IN UP TS  IC IB IE  EB EE ER ED EN EF  LV VT LU LT";
     }
     public String toString(){
         StringBuilder out;
         out = new StringBuilder(getLoopFinitude() + " ");
         out.append(m_loopCommand);
         while (out.length() < 12) { out.append(" "); }
+        if (m_bAttemptUnrolling){
+            out.append("UU  ");
+        }
+        else {
+            out.append("--  ");
+        }
         out.append(cBooleanToChar(getLoopExpressions().bInitAvailable())).append("  ");
         out.append(cBooleanToChar(getLoopExpressions().bUpdateAvailable())).append("  ");
         out.append(cBooleanToChar(getLoopExpressions().bTestAvailable())).append("   ");

--- a/src/main/java/nl/ou/debm/common/feature1/LoopPatternNode.java
+++ b/src/main/java/nl/ou/debm/common/feature1/LoopPatternNode.java
@@ -55,6 +55,10 @@ public class LoopPatternNode {
         m_iNParents = 0;
     }
 
+    public LoopPatternNode(LoopInfo li) {
+        setLoopInfo(li);
+    }
+
     /////////////////
     // normal methods
     /////////////////

--- a/src/main/java/nl/ou/debm/common/feature1/LoopPatternNode.java
+++ b/src/main/java/nl/ou/debm/common/feature1/LoopPatternNode.java
@@ -68,7 +68,7 @@ public class LoopPatternNode {
         if (child!=null) {
             m_child.add(child);
             child.m_parent = this;
-            IncreaseParentCount(child);
+            setParentCount(child);
         }
         return child;
     }
@@ -77,10 +77,10 @@ public class LoopPatternNode {
      * Increase the number of parents for this node and all its descendants.
      * @param node  root node to be affected
      */
-    private void IncreaseParentCount(LoopPatternNode node){
-        node.m_iNParents++;
+    private void setParentCount(LoopPatternNode node){
+        node.m_iNParents = node.m_parent.m_iNParents+1;
         for (var item : node.m_child){
-            IncreaseParentCount(item);
+            setParentCount(item);
         }
     }
 

--- a/src/main/java/nl/ou/debm/common/feature1/LoopProducer.java
+++ b/src/main/java/nl/ou/debm/common/feature1/LoopProducer.java
@@ -35,6 +35,8 @@ public class LoopProducer implements IFeature, IStatementGenerator  {
     /////////////////////////////
     public static final int ILOOPVARLOWVALUELOWBOUND=0;             // lower bound for loops is between 0...20
     public static final int ILOOPVARLOWVALUEHIGHBOUND=10;
+    public static final int ILOOPMINNUMBEROFITERATIONSFORUNROLLING = 5;    // minimum number of iterations when seducing for loop unrolling
+    public static final int ILOOPMAXNUMBEROFITERATIONSFORUNROLLING = 23;    // maximum number of iterations when seducing for loop unrolling
     public static final int ILOOPVARHIGHVALUELOWBOUND=2000;         // higher bound for loops is between 2000...10000
     public static final int ILOOPVARHIGHVALUEHIGHBOUND=10000;
     public static final int ILOOPUPDATEIFNOTONELOWBOUND=3;          // +=? and -=? --> ? lies between 3...15

--- a/src/main/java/nl/ou/debm/common/feature1/LoopProducer.java
+++ b/src/main/java/nl/ou/debm/common/feature1/LoopProducer.java
@@ -173,8 +173,8 @@ public class LoopProducer implements IFeature, IStatementGenerator  {
         /////////////
         // loop setup
         /////////////
-        list.add("// " + LoopInfo.strToStringHeader());         // useful debugging info
-        list.add("// " + loopInfo);                             // useful debugging info
+        list.add("/* " + LoopInfo.strToStringHeader() + " */"); // useful debugging info
+        list.add("/* " + loopInfo + " */");                     // useful debugging info
         list.add(loopInfo.getStartMarker(pattern.iGetNumParents()).strPrintf());        // mark code
         list.add(loopInfo.strGetLoopInit());                    // put init statement (this may be only a comment, when using for)
         list.add(loopInfo.strGetLoopCommand());                 // put loop command (for/do/while)

--- a/src/main/java/nl/ou/debm/common/feature1/LoopProducer.java
+++ b/src/main/java/nl/ou/debm/common/feature1/LoopProducer.java
@@ -558,7 +558,8 @@ public class LoopProducer implements IFeature, IStatementGenerator  {
                 // ... but there are children, so try to find a child that is not unrollable and switch
                 while (true) {
                     for (int c = 0; c < patternNode.iGetNumChildren(); ++c) {
-                        if (patternNode.getChild(c).getLoopInfo().getUnrolling() == ELoopUnrollTypes.NO_ATTEMPT) {
+                        if ((patternNode.getChild(c).getLoopInfo().getUnrolling() == ELoopUnrollTypes.NO_ATTEMPT) &&
+                            (!patternNode.getChild(c).getLoopInfo().bGetELC_BreakOutNestedLoops())) {
                             // found a child that is not unroll-able, so switch them
                             var tmp = patternNode.getLoopInfo();
                             patternNode.setLoopInfo(patternNode.getChild(c).getLoopInfo());
@@ -578,7 +579,8 @@ public class LoopProducer implements IFeature, IStatementGenerator  {
                         lpn = new LoopPatternNode();
                         lpn.setLoopInfo(getNextLoopInfo());
                         patternNode.addChild(lpn);
-                    } while (lpn.getLoopInfo().getUnrolling() != ELoopUnrollTypes.NO_ATTEMPT);
+                    } while ((lpn.getLoopInfo().getUnrolling() != ELoopUnrollTypes.NO_ATTEMPT) ||
+                             (lpn.getLoopInfo().bGetELC_BreakOutNestedLoops()));
                 }
             }
         }

--- a/src/main/java/nl/ou/debm/test/LoopPatternNodeTest.java
+++ b/src/main/java/nl/ou/debm/test/LoopPatternNodeTest.java
@@ -96,21 +96,13 @@ public class LoopPatternNodeTest {
 
     @Test
     public void TestLoopAttaching(){
-        // can only be run when these are (temporarily) made public:
-        //
-        //: LoopProducer.getNextLoopPattern();
-        //: LoopProducer.AttachLoops();
-
-
-        var gen = new CGenerator();
-        var prod = new LoopProducer(gen);
+        var prod = new LoopProducer(new CGenerator());
         m_iTotalNodesChecked = 0;
 
-        for (int c=0; c<10000; ++c){
-            var node = prod.getNextLoopPattern();
-            prod.AttachLoops(node);
+        for (int c=0; c<100000; ++c){
+            var node = prod.getNextFilledLoopPattern();
             checkBreakMulti(node);
-//            recurseCheckNodesForUnrolling(node, 0);
+            recurseCheckNodesForUnrolling(node, 0);
         }
 
         System.out.println("Total nodes checked: " + m_iTotalNodesChecked);

--- a/src/main/java/nl/ou/debm/test/LoopPatternNodeTest.java
+++ b/src/main/java/nl/ou/debm/test/LoopPatternNodeTest.java
@@ -109,8 +109,8 @@ public class LoopPatternNodeTest {
         for (int c=0; c<10000; ++c){
             var node = prod.getNextLoopPattern();
             prod.AttachLoops(node);
-            recurseCheckNodes(node, 0);
             checkBreakMulti(node);
+//            recurseCheckNodesForUnrolling(node, 0);
         }
 
         System.out.println("Total nodes checked: " + m_iTotalNodesChecked);
@@ -118,7 +118,7 @@ public class LoopPatternNodeTest {
 
     }
 
-    private void recurseCheckNodes(LoopPatternNode node, int iNumberOfParents){
+    private void recurseCheckNodesForUnrolling(LoopPatternNode node, int iNumberOfParents){
         m_iTotalNodesChecked ++;
 
         // assert that, if this node has an unroll-able loop, it has no children
@@ -128,7 +128,7 @@ public class LoopPatternNodeTest {
         }
         // check children
         for (int c=0; c<node.iGetNumChildren(); ++c){
-            recurseCheckNodes(node.getChild(c), iNumberOfParents + 1);
+            recurseCheckNodesForUnrolling(node.getChild(c), iNumberOfParents + 1);
         }
     }
 
@@ -168,7 +168,8 @@ public class LoopPatternNodeTest {
                 ShowNodeAndChildren(node);
                 for (int lev = 0; lev < 9; ++lev){
                     for (var item : lst.get(lev)) {
-                        System.out.println("lev=" + lev + ", ID=" + item.iGetID() + ", breakout=" + item.getLoopInfo().bGetELC_BreakOutNestedLoops());
+                        System.out.println("lev=" + lev + ", ID=" + item.iGetID() + ", breakout=" + item.getLoopInfo().bGetELC_BreakOutNestedLoops() +
+                                ", unrollable=" + item.getLoopInfo().getUnrolling());
                     }
                 }
             }

--- a/src/main/java/nl/ou/debm/test/LoopPatternNodeTest.java
+++ b/src/main/java/nl/ou/debm/test/LoopPatternNodeTest.java
@@ -1,9 +1,14 @@
 package nl.ou.debm.test;
 
+import nl.ou.debm.common.feature1.ELoopUnrollTypes;
 import nl.ou.debm.common.feature1.LoopPatternNode;
+import nl.ou.debm.common.feature1.LoopProducer;
+import nl.ou.debm.producer.CGenerator;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class LoopPatternNodeTest {
 
@@ -85,5 +90,46 @@ public class LoopPatternNodeTest {
         }
     }
 
+    int m_iTotalNodesChecked = 0;
+    int m_iTotalUnrollAssertions = 0;
+
+    @Test
+    public void TestLoopAttaching(){
+        // can only be run when these are (temporarily) made public:
+        //
+        //: LoopProducer.getNextLoopPattern();
+        //: LoopProducer.AttachLoops();
+
+
+        var gen = new CGenerator();
+        var prod = new LoopProducer(gen);
+        m_iTotalNodesChecked = 0;
+
+        for (int c=0; c<10000; ++c){
+            var node = prod.getNextLoopPattern();
+            prod.AttachLoops(node);
+            recurseCheckNodes(node, 0);
+        }
+
+        // TODO: make sure the break-out-many-property is maintained + checked!
+
+        System.out.println("Total nodes checked: " + m_iTotalNodesChecked);
+        System.out.println("Total unrolled nodes asserted: " + m_iTotalUnrollAssertions);
+
+    }
+
+    private void recurseCheckNodes(LoopPatternNode node, int iNumberOfParents){
+        m_iTotalNodesChecked ++;
+
+        // assert that, if this node has an unroll-able loop, it has no children
+        if (node.getLoopInfo().getUnrolling() != ELoopUnrollTypes.NO_ATTEMPT){
+            assertEquals(0, node.iGetNumChildren());
+            m_iTotalUnrollAssertions ++;
+        }
+        // check children
+        for (int c=0; c<node.iGetNumChildren(); ++c){
+            recurseCheckNodes(node.getChild(c), iNumberOfParents + 1);
+        }
+    }
 
 }

--- a/src/main/java/nl/ou/debm/test/TestLoopSpecs.java
+++ b/src/main/java/nl/ou/debm/test/TestLoopSpecs.java
@@ -24,9 +24,17 @@ public class TestLoopSpecs {
         System.out.println("#####: " + strToStringHeader());
         int cnt = 0;
         for (var q : li){
-            if (q.bGetAttemptUnrolling()) {
+            if (q.getUnrolling() != ELoopUnrollTypes.NO_ATTEMPT) {
                 System.out.print(Misc.strGetNumberWithPrefixZeros(cnt, 5) + ": ");
-                System.out.println(q);
+                System.out.print(q);
+                if (q.getLoopVar()==null){
+                    System.out.println();
+                }
+                else {
+                    System.out.print(" I:" + q.getLoopVar().strInitExpression + "  ");
+                    System.out.print(" U:" + q.getLoopVar().strUpdateExpression + "  ");
+                    System.out.println(" T: " + q.getLoopVar().strTestExpression);
+                }
             }
             cnt++;
         }
@@ -71,7 +79,6 @@ public class TestLoopSpecs {
 //                    (l.getLoopExpressions().bTestAvailable()) &&
 //                    (l.getLoopVar().eTestType == ELoopVarTestOperators.NON_EQUAL) &&
 //                    (l.bGetELC_UseBreak() == true) &&
-                    (l.bGetAttemptUnrolling()) &&
 
                     (true)
             ){

--- a/src/main/java/nl/ou/debm/test/TestLoopSpecs.java
+++ b/src/main/java/nl/ou/debm/test/TestLoopSpecs.java
@@ -24,10 +24,10 @@ public class TestLoopSpecs {
         System.out.println("#####: " + strToStringHeader());
         int cnt = 0;
         for (var q : li){
-            //if (q.getLoopVar().eUpdateType == ELoopVarUpdateTypes.INCREASE_OTHER) {
+            if (q.bGetAttemptUnrolling()) {
                 System.out.print(Misc.strGetNumberWithPrefixZeros(cnt, 5) + ": ");
                 System.out.println(q);
-            //}
+            }
             cnt++;
         }
 
@@ -56,22 +56,22 @@ public class TestLoopSpecs {
         LoopInfo loop;
         for (var l : li){
             if (
-                    (l.getLoopCommand() == ELoopCommands.FOR) &&
-                    (l.getLoopFinitude() == ELoopFinitude.PFL) &&
-                    (l.getLoopExpressions() == ELoopExpressions.ALL ) &&
-                    (l.bGetELC_UseBreak()) &&
-                    (l.bGetELC_UseReturn()) &&
-                    (l.bGetELC_UseExit()) &&
-                    (l.bGetELC_UseGotoDirectlyAfterThisLoop()) &&
-
-                    (l.bGetILC_UseContinue()) &&
-                    (l.bGetILC_UseGotoBegin()) &&
-                    (l.bGetILC_UseGotoEnd()) &&
+//                    (l.getLoopCommand() == ELoopCommands.FOR) &&
+//                    (l.getLoopFinitude() == ELoopFinitude.PFL) &&
+//                    (l.getLoopExpressions() == ELoopExpressions.ALL ) &&
+//                    (l.bGetELC_UseBreak()) &&
+//                    (l.bGetELC_UseReturn()) &&
+//                    (l.bGetELC_UseExit()) &&
+//                    (l.bGetELC_UseGotoDirectlyAfterThisLoop()) &&
+//
+//                    (l.bGetILC_UseContinue()) &&
+//                    (l.bGetILC_UseGotoBegin()) &&
+//                    (l.bGetILC_UseGotoEnd()) &&
 //                    (l.getLoopVar().eUpdateType == ELoopVarUpdateTypes.DECREASE_BY_INPUT ) &&
 //                    (l.getLoopExpressions().bTestAvailable()) &&
 //                    (l.getLoopVar().eTestType == ELoopVarTestOperators.NON_EQUAL) &&
 //                    (l.bGetELC_UseBreak() == true) &&
-
+                    (l.bGetAttemptUnrolling()) &&
 
                     (true)
             ){


### PR DESCRIPTION
This PR implements loop unrolling in the producer by introducing loops that may be easily unrolled, as these
- do not contain other loops, 
- do not contain dummy-commands,
- do not contain loop control flow,
- have compile-time calculable loop variables,
- do not always print the loop variable,
- make a limited number of iterations.
- 