### PR TITLE
Producertweaks

### DIFF
--- a/src/main/java/nl/ou/debm/common/feature1/LoopInfo.java
+++ b/src/main/java/nl/ou/debm/common/feature1/LoopInfo.java
@@ -304,6 +304,42 @@ public class LoopInfo {
         return ELoopExpressions.INIT_UPDATE;
     }
 
+    /**
+     * Returns true if the loop should be made conditional in the code. Any loop that will not be able
+     * to jump directly after the loop, must be conditional, because otherwise code will be optimized
+     * away for being unreachable
+     * @return Make loop conditional or not.
+     */
+    public boolean bMakeConditional(){
+        // all TIL-loops must be conditional
+        if (getLoopFinitude()==ELoopFinitude.TIL){
+            return true;
+        }
+        // left: all PFL's
+
+        // every PFL with a test condition is fine
+        if (getLoopVar()!=null){
+            if (getLoopVar().eTestType!=ELoopVarTestTypes.UNUSED){
+                return false;
+            }
+        }
+        // left: PFL's that have no loop-var test
+        //       these *must* have one or more external control flow statements
+        //       because that is the only way to terminate the loop
+
+        // if one of them is a break or a goto-just-after-the-loop -- all is fine
+        if (bGetELC_UseBreak() || bGetELC_UseGotoDirectlyAfterThisLoop()){
+            return false;
+        }
+
+        // left: PFL's that have a loop termination statement such as:
+        //       - return (no execution past the loop because it returns to the function call)
+        //       - exit (no execution past the loop because it terminates the program)
+        //       - goto-further-from-loop (because it skips some code)
+        //       - break-multiple-loops (because it also skips code)
+        return true;
+    }
+
     // part C: access to obtain code
     ////////////////////////////////
 

--- a/src/main/java/nl/ou/debm/common/feature1/LoopProducer.java
+++ b/src/main/java/nl/ou/debm/common/feature1/LoopProducer.java
@@ -95,7 +95,19 @@ public class LoopProducer implements IFeature, IStatementGenerator  {
         m_iSatisfactionCutOff = (int)((double)m_patternRepo.size() * dblGetSatisfactionPercentage());
     }
 
+    /**
+     * Get the percentage of loops to be used in this run.
+     * @return a value between 0.1 and 1.0 (including both)
+     */
     private static double dblGetSatisfactionPercentage(){
+        // calculate the percentage for loops according to a random value
+        // this function assures that the vast majority of c-sources will have between
+        // 25% and 35% of all the loops in the repo. Considering that each container
+        // will contain some 200 sources, we are quite sure to use every loop type
+        // at least once in the container, while also having a substantial number of loops
+        // per c-source /and/ not having too many loops per source (as the size grows
+        // substantially if there are).
+        //
         // random value        number of loops
         // 0                         10%
         // .15                       25%

--- a/src/main/java/nl/ou/debm/common/feature1/LoopProducer.java
+++ b/src/main/java/nl/ou/debm/common/feature1/LoopProducer.java
@@ -54,18 +54,27 @@ public class LoopProducer implements IFeature, IStatementGenerator  {
 
     // class attributes
     ///////////////////
-    private final StatementPrefs m_dummyPrefs = new StatementPrefs(null);
-    private final StatementPrefs m_defaultEmptyPrefs = new StatementPrefs(null);
-    private final static String STRINDENT = "\t";
+    private static final StatementPrefs s_dummyPrefs = new StatementPrefs(null);
+    private static final StatementPrefs s_defaultEmptyPrefs = new StatementPrefs(null);
+    private static final String STRINDENT = "\t";
+    private static final ArrayList<LoopInfo> s_loopRepo = new ArrayList<>();// repo of all possible loops
+    private static int s_iLoopRepoPointer = 0;                             // pointer to /next/ element to be used from the repo
+
+    // class init
+    // ----------
+    static {
+        // copy loop info repo
+        LoopInfo.FillLoopRepo(s_loopRepo, true);
+    }
 
     // object attributes
     ////////////////////
     private final List<LoopPatternNode> m_patternRepo;              // repository of loop patterns
     private int m_iLoopPatternIndex = -1;                           // keep track of used patterns
     private final CGenerator m_cgenerator;                          // generator object that uses this producer
-    private final ArrayList<LoopInfo> m_loopRepo = new ArrayList<>();// repo of all possible loops
-    private int m_iLoopRepoPointer = 0;                             // pointer to /next/ element to be used from the repo
     private boolean m_bSatisfied = false;                           // satisfied flag, is set when the entire repo is processed
+    private int m_iSatisfactionCutOff = 0;                          // minimum number of loops to be produced
+    private int m_iNLoopsProduced = 0;                              // count number of loops produced
 
     // construction
 
@@ -76,14 +85,38 @@ public class LoopProducer implements IFeature, IStatementGenerator  {
     public LoopProducer(CGenerator generator){
         // set pointer to generator
         this.m_cgenerator = generator;
-        // initialise loop repo
-        LoopInfo.FillLoopRepo(m_loopRepo, true);
         // set values for dummy statements, meaning everything is ok...
-        m_dummyPrefs.loop = EStatementPref.NOT_WANTED;                      // ... but disallow loops
-        m_dummyPrefs.compoundStatement = EStatementPref.NOT_WANTED;         // ... and disallow compounds
-        m_dummyPrefs.expression = EStatementPref.NOT_WANTED;                // ... and disallow expressions
+        s_dummyPrefs.loop = EStatementPref.NOT_WANTED;                      // ... but disallow loops
+        s_dummyPrefs.compoundStatement = EStatementPref.NOT_WANTED;         // ... and disallow compounds
+        s_dummyPrefs.expression = EStatementPref.NOT_WANTED;                // ... and disallow expressions
         // get loop pattern repo
         m_patternRepo = LoopPatternNode.getPatternRepo();
+        // set satisfaction cut off
+        m_iSatisfactionCutOff = (int)((double)m_patternRepo.size() * dblGetSatisfactionPercentage());
+    }
+
+    private static double dblGetSatisfactionPercentage(){
+        // random value        number of loops
+        // 0                         10%
+        // .15                       25%
+        // .7                        35%
+        // .995                     100%
+        // between these dots, the number of loops grows linear
+        double randomValue = Misc.rnd.nextDouble();
+        if (randomValue<.15){
+            return dblInterpolate(0,.1, .15, .25, randomValue);
+        }
+        if (randomValue<.7){
+            return dblInterpolate(.15,.25, .7, .35, randomValue);
+        }
+        if (randomValue<.995){
+            return dblInterpolate(.7, .35, 1, 1, randomValue);
+        }
+        return 1;
+    }
+
+    private static double dblInterpolate(double x1, double y1, double x2, double y2, double x){
+        return ((x-x1)/(x2-x1)) * (y2-y1);
     }
 
     @Override
@@ -118,7 +151,7 @@ public class LoopProducer implements IFeature, IStatementGenerator  {
         // check prefs object
         if (internalPrefs == null) {
             // no prefs are wanted, use defaults
-            internalPrefs = m_defaultEmptyPrefs;
+            internalPrefs = s_defaultEmptyPrefs;
         }
 
         // create string list for statements
@@ -170,21 +203,31 @@ public class LoopProducer implements IFeature, IStatementGenerator  {
         String strDirectlyAfterLoopLabel = m_cgenerator.getLabel();
         String strFurtherAfterLoopLabel = m_cgenerator.getLabel();
 
+        ///////////////////////////////////////
+        // make loop conditional if it is a TIL
+        ///////////////////////////////////////
+        // if we don't do this, all code after the loop will be thrown out for being unreachable
+        String strInfIntend = "";
+        if (loopInfo.bMakeConditional()) {
+            list.add("if (getchar()==79) {");
+            strInfIntend = STRINDENT;
+        }
+
         /////////////
         // loop setup
         /////////////
-        list.add("/* " + LoopInfo.strToStringHeader() + " */"); // useful debugging info
-        list.add("/* " + loopInfo + " */");                     // useful debugging info
-        list.add(loopInfo.getStartMarker(pattern.iGetNumParents()).strPrintf());        // mark code
-        list.add(loopInfo.strGetLoopInit());                    // put init statement (this may be only a comment, when using for)
-        list.add(loopInfo.strGetLoopCommand());                 // put loop command (for/do/while)
+        list.add(strInfIntend + "/* " + LoopInfo.strToStringHeader() + " */"); // useful debugging info
+        list.add(strInfIntend + "/* " + loopInfo + " */");                     // useful debugging info
+        list.add(strInfIntend + loopInfo.getStartMarker(pattern.iGetNumParents()).strPrintf());        // mark code
+        list.add(strInfIntend + loopInfo.strGetLoopInit());                    // put init statement (this may be only a comment, when using for)
+        list.add(strInfIntend + loopInfo.strGetLoopCommand());                 // put loop command (for/do/while)
 
         ////////////
         // loop body
         ////////////
 
         // add loop body header
-        list.add(STRINDENT + strBeginOfBodyLabel);              // add start of body label
+        list.add(strInfIntend + STRINDENT + strBeginOfBodyLabel);              // add start of body label
         boolean bPrintVar = false;
         if (loopInfo.getLoopVar() != null) {                    // add start of body marker
             // use loop var in print?
@@ -195,43 +238,43 @@ public class LoopProducer implements IFeature, IStatementGenerator  {
         if (bPrintVar) {
             // print var
             if (loopInfo.getLoopVar().eVarType == ELoopVarTypes.INT) {
-                list.add(STRINDENT + loopInfo.getBodyMarker().strPrintfInteger(loopInfo.strGetLoopVarName()));
+                list.add(strInfIntend + STRINDENT + loopInfo.getBodyMarker().strPrintfInteger(loopInfo.strGetLoopVarName()));
             } else {
-                list.add(STRINDENT + loopInfo.getBodyMarker().strPrintfFloat(loopInfo.strGetLoopVarName()));
+                list.add(strInfIntend + STRINDENT + loopInfo.getBodyMarker().strPrintfFloat(loopInfo.strGetLoopVarName()));
             }
         }
         else {
             // but if no loop var is used, one cannot print it ;-)
-            list.add(STRINDENT + loopInfo.getBodyMarker().strPrintf());
+            list.add(strInfIntend + STRINDENT + loopInfo.getBodyMarker().strPrintf());
         }
 
         // get some dummy commands (but only in non-unrolling loops)
         if (loopInfo.getUnrolling() == ELoopUnrollTypes.NO_ATTEMPT) {
-            addDummies(currentDepth, f, list, STRINDENT);
+            addDummies(currentDepth, f, list, strInfIntend + STRINDENT);
         }
 
         // control flow statements that transfer control out of this loop
         if (loopInfo.bGetELC_UseBreak()){                       // add break if needed
-            list.add(STRINDENT + "if (getchar()==23) {break;}");
+            list.add(strInfIntend + STRINDENT + "if (getchar()==23) {break;}");
         }
         if (loopInfo.bGetELC_UseExit()){                        // add exit it needed
-            list.add(STRINDENT + "if (getchar()==97) {exit(1923);}");
+            list.add(strInfIntend + STRINDENT + "if (getchar()==97) {exit(1923);}");
         }
         if (loopInfo.bGetELC_UseReturn()){                      // add return if needed
             if (f.getType().bIsPrimitive()) {
                 // for any primitive, we can rely on the default value based on the type
-                list.add(STRINDENT + "if (getchar()==31) {return " + f.getType().strDefaultValue(m_cgenerator.structsByName) + ";}");
+                list.add(strInfIntend + STRINDENT + "if (getchar()==31) {return " + f.getType().strDefaultValue(m_cgenerator.structsByName) + ";}");
             }
             else{
                 // for any non-primitive, we must instantiate a return struct
-                list.add(STRINDENT + "if (getchar()==31) {struct " + f.getType().getName() + " out; return out;}");
+                list.add(strInfIntend + STRINDENT + "if (getchar()==31) {struct " + f.getType().getName() + " out; return out;}");
             }
         }
         if (loopInfo.bGetELC_UseGotoDirectlyAfterThisLoop()){   // add goto outside of loop, if needed
-            list.add(STRINDENT + "if (getchar()==19) {goto " + strGotoLabel(strDirectlyAfterLoopLabel) + ";} // goto directly after");
+            list.add(strInfIntend + STRINDENT + "if (getchar()==19) {goto " + strGotoLabel(strDirectlyAfterLoopLabel) + ";} // goto directly after");
         }
         if (loopInfo.bGetELC_UseGotoFurtherFromThisLoop()){     // add goto further outside of loop, if needed
-            list.add(STRINDENT + "if (getchar()==83) {goto " + strGotoLabel(strFurtherAfterLoopLabel) + ";} // goto further after");
+            list.add(strInfIntend + STRINDENT + "if (getchar()==83) {goto " + strGotoLabel(strFurtherAfterLoopLabel) + ";} // goto further after");
         }
 
         // breaking out of nested loops?
@@ -244,14 +287,14 @@ public class LoopProducer implements IFeature, IStatementGenerator  {
             if (pattern.bHasParent()) {
                 // there are parent loops, so we need to do something.
                 // we add a goto with a placeholder
-                list.add(STRINDENT + "if (getchar()==73) {goto " + STRPLACEHOLDER + ";} // goto end of root loop");
+                list.add(strInfIntend + STRINDENT + "if (getchar()==73) {goto " + STRPLACEHOLDER + ";} // goto end of root loop");
                 // if the top loop is closed, all placeholders are substituted with the appropriate label
             }
         }
 
         // get some dummy commands
         if (loopInfo.getUnrolling() == ELoopUnrollTypes.NO_ATTEMPT) {
-            addDummies(currentDepth, f, list, STRINDENT);
+            addDummies(currentDepth, f, list, strInfIntend + STRINDENT);
         }
 
         // nested loop or loops wanted?
@@ -264,36 +307,43 @@ public class LoopProducer implements IFeature, IStatementGenerator  {
             getLoopStatements(currentDepth, f, list2, pattern.getChild(ch));
             // copy list with indention
             for (var item : list2){
-                list.add(STRINDENT + item);
+                list.add(strInfIntend + STRINDENT + item);
             }
         }
 
         // control flow statements that transfer control within this loop
         if (loopInfo.bGetILC_UseContinue()){                    // add continue if needed
-            list.add(STRINDENT + "if (getchar()==67) {continue;}");
+            list.add(strInfIntend + STRINDENT + "if (getchar()==67) {continue;}");
         }
         if (loopInfo.bGetILC_UseGotoBegin()){                   // add goto <begin-of-loop> if needed (no loop var update in this jump)
-            list.add(STRINDENT + "if (getchar()==11) {goto " + strGotoLabel(strBeginOfBodyLabel) + ";} // goto begin of loop body");
+            list.add(strInfIntend + STRINDENT + "if (getchar()==11) {goto " + strGotoLabel(strBeginOfBodyLabel) + ";} // goto begin of loop body");
         }
         if (loopInfo.bGetILC_UseGotoEnd()){                     // add goto <end-of-loop> if needed (loop var will be updated)
-            list.add(STRINDENT + "if (getchar()==17) {goto " + strGotoLabel(strEndOfBodyLabel) + ";} // goto end of loop body");
+            list.add(strInfIntend + STRINDENT + "if (getchar()==17) {goto " + strGotoLabel(strEndOfBodyLabel) + ";} // goto end of loop body");
         }
 
         // get some dummy commands
         if (loopInfo.getUnrolling() == ELoopUnrollTypes.NO_ATTEMPT) {
-            addDummies(currentDepth, f, list, STRINDENT);
+            addDummies(currentDepth, f, list, strInfIntend + STRINDENT);
         }
 
         // finish up body with update command if needed and the closing statements
-        list.add(STRINDENT + strEndOfBodyLabel);
+        list.add(strInfIntend + STRINDENT + strEndOfBodyLabel);
         if ((loopInfo.getLoopCommand() != ELoopCommands.FOR) &&
                 (loopInfo.getLoopExpressions().bUpdateAvailable())){
-            list.add(STRINDENT + loopInfo.strGetCompleteLoopUpdateExpression() + ";");
+            list.add(strInfIntend + STRINDENT + loopInfo.strGetCompleteLoopUpdateExpression() + ";");
         }
         else{
-            list.add(STRINDENT + ";");
+            list.add(strInfIntend + STRINDENT + ";");
         }
-        list.add(loopInfo.strGetLoopTrailer());
+        list.add(strInfIntend + loopInfo.strGetLoopTrailer());
+
+        ///////////////////
+        // close the TIL-if
+        ///////////////////
+        if (loopInfo.bMakeConditional()) {
+            list.add("}");
+        }
 
         /////////////////
         // after the loop
@@ -303,7 +353,7 @@ public class LoopProducer implements IFeature, IStatementGenerator  {
         list.add(loopInfo.getEndMarker().strPrintf());          // after-body-marker
         addDummies(currentDepth, f, list, "");         // get dummy statements
         list.add(strFurtherAfterLoopLabel);                     // and put end-of-all-label
-        list.add(";");
+        list.add(";");                                          // add skip (or be cursed upon by the C compiler grammar)
 
         ////////////////////////////
         // post-process placeholders
@@ -396,19 +446,33 @@ public class LoopProducer implements IFeature, IStatementGenerator  {
      * Get next loop to be implemented and mark the work done
      * @return  all info for the next loop
      */
-    private LoopInfo getNextLoopInfo(){
-        // the loop_repo is shuffled when created in the constructor
+    private synchronized LoopInfo getNextLoopInfo(){
+        // the loop_repo is shuffled when created in the class "constructor"
         // so, we can simply pick one item each time
+        // every time the entire repo is completely used, it is reshuffled
+        //
+        // in case multiple generators do their jobs in multiple threads, we expect
+        // race conditions, because they all use the same class wide repo
+        // therefore, this method is synchronized
 
         // get current loop info
-        var loopInfo = m_loopRepo.get(m_iLoopRepoPointer);
+        var loopInfo = s_loopRepo.get(s_iLoopRepoPointer);
+
+        // increase number of loops produced
+        m_iNLoopsProduced++;
 
         // increase loop info object pointer
-        m_iLoopRepoPointer++;
-        if (m_iLoopRepoPointer == m_loopRepo.size()){
+        s_iLoopRepoPointer++;
+        if (s_iLoopRepoPointer == s_loopRepo.size()){
             // start again
-            m_iLoopRepoPointer = 0;
+            s_iLoopRepoPointer = 0;
+            // re-shuffle repo
+            Collections.shuffle(s_loopRepo);
             // and mark the work as done
+            m_bSatisfied = true;
+        }
+        if (m_iNLoopsProduced >= m_iSatisfactionCutOff){
+            // also stop after earlier cut off
             m_bSatisfied = true;
         }
 
@@ -466,7 +530,7 @@ public class LoopProducer implements IFeature, IStatementGenerator  {
      * @param list  list to be expanded
      */
     private void addDummies(int currentDepth, Function f, List<String> list, String strIndent) {
-        for (var item : m_cgenerator.getNewStatements(currentDepth + 1, f, m_dummyPrefs)) {
+        for (var item : m_cgenerator.getNewStatements(currentDepth + 1, f, s_dummyPrefs)) {
             if (!item.isBlank()) {
                 list.add(strIndent + item); // get dummy statements and indent them
             }

--- a/src/main/java/nl/ou/debm/common/feature1/LoopProducer.java
+++ b/src/main/java/nl/ou/debm/common/feature1/LoopProducer.java
@@ -468,8 +468,9 @@ public class LoopProducer implements IFeature, IStatementGenerator  {
             s_iLoopRepoPointer = 0;
             // re-shuffle repo
             Collections.shuffle(s_loopRepo);
-            // and mark the work as done
-            m_bSatisfied = true;
+            // no longer automatically mark the work as done,
+            // for the repo is now static, so an instance of the LoopProducer
+            // doesn't necessarily start at the beginning of the repo
         }
         if (m_iNLoopsProduced >= m_iSatisfactionCutOff){
             // also stop after earlier cut off

--- a/src/main/java/nl/ou/debm/test/TestLoopSpecs.java
+++ b/src/main/java/nl/ou/debm/test/TestLoopSpecs.java
@@ -1,13 +1,15 @@
 package nl.ou.debm.test;
 
 import nl.ou.debm.common.Misc;
-import nl.ou.debm.common.feature1.*;
+import nl.ou.debm.common.feature1.ELoopUnrollTypes;
+import nl.ou.debm.common.feature1.LoopInfo;
+import nl.ou.debm.common.feature1.LoopPatternNode;
+import nl.ou.debm.common.feature1.LoopProducer;
 import nl.ou.debm.producer.CGenerator;
 import nl.ou.debm.producer.DataType;
 import nl.ou.debm.producer.Function;
 import org.junit.jupiter.api.Test;
 
-import javax.xml.crypto.Data;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -98,4 +100,6 @@ public class TestLoopSpecs {
         }
 
     }
+
+
 }


### PR DESCRIPTION
Problem: always including the entire loop repo makes sources very big and basically very much the same.
So, we only use a part of th loop repo per source: at least 10% of the loops, max 100%. The vast majority of sources will have between 35% and 45% of the loops. We use a static loop repo that is suffled every time it is completely used. This makes loop usage very random while also ensuring that all loops types will be used many times in a container.
Finally, we corrected for optimization. A compiler will not compile code after a TIL, since that code is unreachable. By making TIL's conditional loops (put them in a if-getchar()-construct), we make sure that everything after the loop will be reachable and thus will be compiled.