### PR TITLE
Abstracting testresult

### DIFF
--- a/src/main/java/nl/ou/debm/assessor/Assessor.java
+++ b/src/main/java/nl/ou/debm/assessor/Assessor.java
@@ -251,18 +251,19 @@ public class Assessor {
         var sb = new StringBuilder();
         sb.append("<html><body>");
         sb.append("<table>");
-        sb.append("<tr style='text-align:right; font-weight: bold'><th>Description (unit)</th><th>Architecture</th><th>Compiler</th><th>Optimization</th><th>Min score</th><th>Actual score</th><th>Max score</th><th>%</th></tr>");
+        sb.append("<tr style='text-align:center; font-weight: bold'><th>Description (unit)</th><th>Architecture</th><th>Compiler</th><th>Optimization</th><th>Min score</th><th>Actual score</th><th>Max score</th><th>Target score</th><th>% min/max</th></tr>");
 
         for (var item : input){
             sb.append("<tr>");
             sb.append("<td>").append(item.getWhichTest().strTestDescription()).append(" (").append(item.getWhichTest().strTestUnit()).append(")</td>");
-            appendCell(sb, item.getArchitecture(), ETextAlign.CENTER, ETextColour.BLACK);
-            appendCell(sb, item.getCompiler(), ETextAlign.CENTER, ETextColour.BLACK);
-            appendCell(sb, item.getOptimization(), ETextAlign.CENTER, ETextColour.BLACK);
-            appendCell(sb, item.dblGetLowBound(), ETextAlign.RIGHT, ETextColour.GREY);
-            appendCell(sb, item.dblGetActualValue(), ETextAlign.RIGHT, ETextColour.BLACK);
-            appendCell(sb, item.dblGetHighBound(), ETextAlign.RIGHT, ETextColour.GREY);
-            appendCell(sb, item.strGetPercentage(), ETextAlign.RIGHT, ETextColour.GREY);
+            appendCell(sb, item.getArchitecture(), ETextAlign.CENTER, ETextColour.BLACK, 0);
+            appendCell(sb, item.getCompiler(), ETextAlign.CENTER, ETextColour.BLACK,0 );
+            appendCell(sb, item.getOptimization(), ETextAlign.CENTER, ETextColour.BLACK, 0);
+            appendCell(sb, item.dblGetLowBound(), ETextAlign.RIGHT, ETextColour.GREY, item.iGetNumberOfDecimalsToBePrinted());
+            appendCell(sb, item.dblGetActualValue(), ETextAlign.RIGHT, ETextColour.BLACK, item.iGetNumberOfDecimalsToBePrinted());
+            appendCell(sb, item.dblGetHighBound(), ETextAlign.RIGHT, ETextColour.GREY, item.iGetNumberOfDecimalsToBePrinted());
+            appendCell(sb, item.dblGetTarget(), ETextAlign.RIGHT, ETextColour.GREY, item.iGetNumberOfDecimalsToBePrinted());
+            appendCell(sb, item.strGetPercentage(), ETextAlign.RIGHT, ETextColour.GREY, -1);
             sb.append("</tr>");
         }
 
@@ -308,12 +309,17 @@ public class Assessor {
         }
     }
 
-    private static StringBuilder appendCell(StringBuilder sb, Object oWhat, ETextAlign textAlign, ETextColour textColour){
+    private static StringBuilder appendCell(StringBuilder sb, Object oWhat, ETextAlign textAlign, ETextColour textColour, int iNumberOfDecimals){
         sb.append("<td style='");
         sb.append(textAlign.strStyleProperty());
         sb.append(textColour.strStyleProperty());
         sb.append("'>");
         String strWhat = null;
+        if (bIsNumeric(oWhat)){
+            double val = (double)oWhat;
+            String strFormat = "%." + iNumberOfDecimals + "f";
+            sb.append(String.format(strFormat, val));
+        }
         if (oWhat instanceof String){
             strWhat = (String)oWhat;
         }
@@ -331,5 +337,12 @@ public class Assessor {
         }
         sb.append("</td>");
         return sb;
+    }
+
+    private static boolean bIsNumeric(Object oWhat){
+        return (oWhat instanceof Integer) ||
+               (oWhat instanceof Long) ||
+               (oWhat instanceof Double) ||
+               (oWhat instanceof Float);
     }
 }

--- a/src/main/java/nl/ou/debm/assessor/Assessor.java
+++ b/src/main/java/nl/ou/debm/assessor/Assessor.java
@@ -316,7 +316,19 @@ public class Assessor {
         sb.append("'>");
         String strWhat = null;
         if (bIsNumeric(oWhat)){
-            double val = (double)oWhat;
+            double val = 0;
+            if (oWhat instanceof Double){
+                val = (Double)oWhat;
+            }
+            else if (oWhat instanceof Float){
+                val = (double)((Float)oWhat);
+            }
+            else if (oWhat instanceof Integer){
+                val = (double)((Integer)oWhat);
+            }
+            else if (oWhat instanceof Long){
+                val = (double)((Long)oWhat);
+            }
             String strFormat = "%." + iNumberOfDecimals + "f";
             sb.append(String.format(strFormat, val));
         }

--- a/src/main/java/nl/ou/debm/assessor/Assessor.java
+++ b/src/main/java/nl/ou/debm/assessor/Assessor.java
@@ -249,9 +249,15 @@ public class Assessor {
      */
     public static void generateReport(List<IAssessor.TestResult> input, String strHTMLOutputFile){
         var sb = new StringBuilder();
-        sb.append("<html><body>");
+        sb.append("<html>");
+        sb.append("<head>");
+        sb.append("<style>");
+        sb.append("table, th, td {border: 1px solid black; border-collapse: collapse;}");
+        sb.append("</style>");
+        sb.append("</head>");
+        sb.append("<body>");
         sb.append("<table>");
-        sb.append("<tr style='text-align:center; font-weight: bold'><th>Description (unit)</th><th>Architecture</th><th>Compiler</th><th>Optimization</th><th>Min score</th><th>Actual score</th><th>Max score</th><th>Target score</th><th>% min/max</th></tr>");
+        sb.append("<tr style='text-align:center; font-weight: bold'><th>Description (unit)</th><th>Architecture</th><th>Compiler</th><th>Optimization</th><th>Min score</th><th>Actual score</th><th>Max score</th><th>Target score</th><th>% min/max</th><th># tests</th></tr>");
 
         for (var item : input){
             sb.append("<tr>");
@@ -264,6 +270,7 @@ public class Assessor {
             appendCell(sb, item.dblGetHighBound(), ETextAlign.RIGHT, ETextColour.GREY, item.iGetNumberOfDecimalsToBePrinted());
             appendCell(sb, item.dblGetTarget(), ETextAlign.RIGHT, ETextColour.GREY, item.iGetNumberOfDecimalsToBePrinted());
             appendCell(sb, item.strGetPercentage(), ETextAlign.RIGHT, ETextColour.GREY, -1);
+            appendCell(sb, item.iGetNumberOfTests(), ETextAlign.RIGHT, ETextColour.GREY, 0);
             sb.append("</tr>");
         }
 

--- a/src/main/java/nl/ou/debm/assessor/Assessor.java
+++ b/src/main/java/nl/ou/debm/assessor/Assessor.java
@@ -170,7 +170,8 @@ public class Assessor {
         for (var item : list){
             out.addAll(item);
         }
-        IAssessor.TestResult.aggregate(out);
+        var aggregated = IAssessor.TestResult.aggregate(out);
+        generateReport(aggregated, Path.of(strContainersBaseFolder, "report.html").toString());
 
         // remove temporary folder
         bFolderAndAllContentsDeletedOK(tempDir);

--- a/src/main/java/nl/ou/debm/assessor/Assessor.java
+++ b/src/main/java/nl/ou/debm/assessor/Assessor.java
@@ -63,11 +63,11 @@ public class Assessor {
         feature.add(new FunctionAssessor());
     }
 
-    public List<IAssessor.SingleTestResult> RunTheTests(final String strContainersBaseFolder, final String strDecompileScript, final boolean allowMissingBinaries) throws Exception {
+    public List<IAssessor.TestResult> RunTheTests(final String strContainersBaseFolder, final String strDecompileScript, final boolean allowMissingBinaries) throws Exception {
         var reuseDecompilersOutput = false;
 
         // create list to be able to aggregate
-        final List<List<IAssessor.SingleTestResult>> list = new ArrayList<>();
+        final List<List<IAssessor.TestResult>> list = new ArrayList<>();
 
         // set root path, to be used program-wide (as it is a static)
         Environment.containerBasePath = strContainersBaseFolder;
@@ -166,11 +166,11 @@ public class Assessor {
         for (var item : list){
             size += item.size();
         }
-        var out = new ArrayList<IAssessor.SingleTestResult>(size);
+        var out = new ArrayList<IAssessor.TestResult>(size);
         for (var item : list){
             out.addAll(item);
         }
-        IAssessor.SingleTestResult.aggregate(out);
+        IAssessor.TestResult.aggregate(out);
 
         // remove temporary folder
         bFolderAndAllContentsDeletedOK(tempDir);
@@ -247,21 +247,22 @@ public class Assessor {
      * @param input  list of all the presented test results
      * @param strHTMLOutputFile  target file
      */
-    public static void generateReport(List<IAssessor.SingleTestResult> input, String strHTMLOutputFile){
+    public static void generateReport(List<IAssessor.TestResult> input, String strHTMLOutputFile){
         var sb = new StringBuilder();
         sb.append("<html><body>");
         sb.append("<table>");
-        sb.append("<tr><th>Description (unit)</th><th>Architecture</th><th>Compiler</th><th>Optimization</th><th>Score</th><th>Max score</th><th style='text-align:right'>%</th></tr>");
+        sb.append("<tr style='text-align:right; font-weight: bold'><th>Description (unit)</th><th>Architecture</th><th>Compiler</th><th>Optimization</th><th>Min score</th><th>Actual score</th><th>Max score</th><th>%</th></tr>");
 
         for (var item : input){
             sb.append("<tr>");
-            sb.append("<td>").append(item.whichTest.strTestDescription()).append(" (").append(item.whichTest.strTestUnit()).append(")</td>");
-            appendCell(sb, item.compilerConfig.architecture);
-            appendCell(sb, item.compilerConfig.compiler);
-            appendCell(sb, item.compilerConfig.optimization);
-            sb.append("<td style='text-align:right'>").append(item.dblActualValue).append("</td>");
-            sb.append("<td style='text-align:right'>").append(item.dblHighBound).append("</td>");
-            sb.append("<td style='text-align:right'>").append(String.format("%.2f", getPercentage(item))).append("%</td>");
+            sb.append("<td>").append(item.getWhichTest().strTestDescription()).append(" (").append(item.getWhichTest().strTestUnit()).append(")</td>");
+            appendCell(sb, item.getArchitecture(), ETextAlign.CENTER, ETextColour.BLACK);
+            appendCell(sb, item.getCompiler(), ETextAlign.CENTER, ETextColour.BLACK);
+            appendCell(sb, item.getOptimization(), ETextAlign.CENTER, ETextColour.BLACK);
+            appendCell(sb, item.dblGetLowBound(), ETextAlign.RIGHT, ETextColour.GREY);
+            appendCell(sb, item.dblGetActualValue(), ETextAlign.RIGHT, ETextColour.BLACK);
+            appendCell(sb, item.dblGetHighBound(), ETextAlign.RIGHT, ETextColour.GREY);
+            appendCell(sb, item.strGetPercentage(), ETextAlign.RIGHT, ETextColour.GREY);
             sb.append("</tr>");
         }
 
@@ -279,8 +280,39 @@ public class Assessor {
         }
     }
 
-    private static StringBuilder appendCell(StringBuilder sb, Object oWhat){
-        sb.append("<td>");
+    private enum ETextAlign{
+        LEFT, CENTER, RIGHT;
+        public String strStyleProperty(){
+            switch (this) {
+                case LEFT -> { return "text-align:left;";
+                }
+                case CENTER -> { return "text-align:center;";
+                }
+                case RIGHT -> { return "text-align:right;";
+                }
+            }
+            return "";
+        }
+    }
+
+    private enum ETextColour{
+        BLACK, GREY;
+        public String strStyleProperty(){
+            switch (this) {
+                case BLACK -> { return "color:black;";
+                }
+                case GREY -> { return "color:grey;";
+                }
+            }
+            return "";
+        }
+    }
+
+    private static StringBuilder appendCell(StringBuilder sb, Object oWhat, ETextAlign textAlign, ETextColour textColour){
+        sb.append("<td style='");
+        sb.append(textAlign.strStyleProperty());
+        sb.append(textColour.strStyleProperty());
+        sb.append("'>");
         String strWhat = null;
         if (oWhat instanceof String){
             strWhat = (String)oWhat;
@@ -299,12 +331,5 @@ public class Assessor {
         }
         sb.append("</td>");
         return sb;
-    }
-
-    private static double getPercentage(IAssessor.SingleTestResult testResult){
-        var margin = testResult.dblHighBound - testResult.dblLowBound;
-        if(margin == 0)
-            margin = 100;
-        return 100 * testResult.dblActualValue / margin;
     }
 }

--- a/src/main/java/nl/ou/debm/assessor/ETestCategories.java
+++ b/src/main/java/nl/ou/debm/assessor/ETestCategories.java
@@ -40,16 +40,16 @@ public enum ETestCategories {
             case FEATURE1_NUMBER_OF_LOOPS_GENERAL -> {  return "Number of loops found";              }
             case FEATURE1_NUMBER_OF_UNROLLED_LOOPS -> { return "Number of unrolled loops found";     }
 
-            case FEATURE3_FUNCTION_IDENTIFICATION -> {  return "Number of unrolled loops found";     }
-            case FEATURE3_FUNCTION_START -> {           return "Number of unrolled loops found";     }
-            case FEATURE3_FUNCTION_PROLOGUE_RATE -> {   return "Number of unrolled loops found";     }
-            case FEATURE3_FUNCTION_EPILOGUE_RATE -> {   return "Number of unrolled loops found";     }
-            case FEATURE3_FUNCTION_END -> {             return "Number of unrolled loops found";     }
-            case FEATURE3_RETURN -> {                   return "Number of unrolled loops found";     }
-            case FEATURE3_PERFECT_BOUNDARIES -> {       return "Number of unrolled loops found";     }
-            case FEATURE3_UNREACHABLE_FUNCTION -> {     return "Number of unrolled loops found";     }
-            case FEATURE3_TOTAL_FUNCTION_CALLS -> {     return "Number of unrolled loops found";     }
-            case FEATURE3_VARIADIC_FUNCTION -> {        return "Number of unrolled loops found";     }
+            case FEATURE3_FUNCTION_IDENTIFICATION -> {  return "Number of found functions";     }
+            case FEATURE3_FUNCTION_START -> {           return "Number of found function starts";     }
+            case FEATURE3_FUNCTION_PROLOGUE_RATE -> {   return "Number of prologue statements";     }
+            case FEATURE3_FUNCTION_EPILOGUE_RATE -> {   return "Number of epilogue statements";     }
+            case FEATURE3_FUNCTION_END -> {             return "Number of function ends";     }
+            case FEATURE3_RETURN -> {                   return "Number of found return statements";     }
+            case FEATURE3_PERFECT_BOUNDARIES -> {       return "Number of functions with perfectly found boundaries";     }
+            case FEATURE3_UNREACHABLE_FUNCTION -> {     return "Number of unreachable functions found";     }
+            case FEATURE3_TOTAL_FUNCTION_CALLS -> {     return "Number of correctly identified total calls";     }
+            case FEATURE3_VARIADIC_FUNCTION -> {        return "F1-score for variadic functions";     }
         }
         return "";
     }

--- a/src/main/java/nl/ou/debm/assessor/IAssessor.java
+++ b/src/main/java/nl/ou/debm/assessor/IAssessor.java
@@ -5,6 +5,7 @@ import nl.ou.debm.common.antlr.CLexer;
 import nl.ou.debm.common.antlr.CParser;
 import nl.ou.debm.common.antlr.LLVMIRLexer;
 import nl.ou.debm.common.antlr.LLVMIRParser;
+import nl.ou.debm.common.feature3.BooleanScore;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -448,6 +449,8 @@ public interface IAssessor {
                 m_lngLowBound += rh.m_lngLowBound;
                 m_lngActualValue += rh.m_lngActualValue;
                 m_lngHighBound += rh.m_lngHighBound;
+            }else{
+                super.aggregateAbstractValues(rhs);
             }
         }
     }

--- a/src/main/java/nl/ou/debm/assessor/IAssessor.java
+++ b/src/main/java/nl/ou/debm/assessor/IAssessor.java
@@ -247,7 +247,7 @@ public interface IAssessor {
                 if (!input.isEmpty()) {
                     // to leave the original list alone, we make a copy and sort that
                     var tmpList = new ArrayList<>(input);
-                    tmpList.sort(new SingleTestResultComparator());
+                    tmpList.sort(new TestResultComparator());
                     // the first item must be copied anyway
                     outList.add(tmpList.get(0).makeCopy());
                     int p_in=1;
@@ -309,7 +309,7 @@ public interface IAssessor {
             var tempList = new ArrayList<TestResult>(input.size());
             for (var item : input){
                 var t = item.makeCopy();
-                aggregator.AdaptSingleTestResult(t);
+                aggregator.AdaptTestResult(t);
                 tempList.add(t);
             }
             return aggregate(tempList);
@@ -455,7 +455,7 @@ public interface IAssessor {
     /**
      * Comparator class for SingleTestResults, sorting only on test parameters (test/arch/comp/opt)
      */
-    class SingleTestResultComparator implements Comparator<TestResult>{
+    class TestResultComparator implements Comparator<TestResult>{
         @Override
         public int compare(TestResult o1, TestResult o2) {
             return TestResult.staticCompare(o1, o2);
@@ -466,12 +466,12 @@ public interface IAssessor {
      * Interface to make it easier to aggregate in many different ways
      */
     interface IAggregateWhat{
-        void AdaptSingleTestResult(TestResult s);
+        void AdaptTestResult(TestResult s);
     }
 
     class AggregateOverArchitecture implements IAggregateWhat{
         @Override
-        public void AdaptSingleTestResult(TestResult s) {
+        public void AdaptTestResult(TestResult s) {
             s.m_compilerConfig.compiler = null;
             s.m_compilerConfig.optimization = null;
         }
@@ -479,7 +479,7 @@ public interface IAssessor {
 
     class AggregateOverCompiler implements IAggregateWhat{
         @Override
-        public void AdaptSingleTestResult(TestResult s) {
+        public void AdaptTestResult(TestResult s) {
             s.m_compilerConfig.architecture = null;
             s.m_compilerConfig.optimization = null;
         }
@@ -487,7 +487,7 @@ public interface IAssessor {
 
     class AggregateOverOptimization implements IAggregateWhat{
         @Override
-        public void AdaptSingleTestResult(TestResult s) {
+        public void AdaptTestResult(TestResult s) {
             s.m_compilerConfig.architecture = null;
             s.m_compilerConfig.compiler = null;
         }

--- a/src/main/java/nl/ou/debm/assessor/IAssessor.java
+++ b/src/main/java/nl/ou/debm/assessor/IAssessor.java
@@ -66,6 +66,7 @@ public interface IAssessor {
         public abstract double dblGetLowBound();
         public abstract double dblGetActualValue();
         public abstract double dblGetHighBound();
+        public abstract double dblGetTarget();
         public abstract int iGetNumberOfDecimalsToBePrinted();
 
         // copy mechanism
@@ -345,6 +346,11 @@ public interface IAssessor {
 
         @Override
         public double dblGetHighBound() {
+            return m_dblHighBound;
+        }
+
+        @Override
+        public double dblGetTarget() {
             return m_dblHighBound;
         }
 

--- a/src/main/java/nl/ou/debm/assessor/IAssessor.java
+++ b/src/main/java/nl/ou/debm/assessor/IAssessor.java
@@ -319,15 +319,15 @@ public interface IAssessor {
     /**
      * Implementation class for test results. This class is used for results that use simple counting, for
      * example: we count the number of loops in de decoded c-code in relation to the number of loops
-     * introduced in the original code.
-     *
-     * As this is a simple counting class, the lower bound is always set to 0 and not kept in the attributes.
+     * introduced in the original code.<br>
+     * As we only count, we use longs instead of doubles.
      *
      */
     class CountTestResult extends TestResult{
 
-        private double m_dblActualValue = 0;
-        private double m_dblHighBound = 0;
+        private long m_lngLowBound=0;
+        private long m_lngActualValue = 0;
+        private long m_lngHighBound = 0;
 
 
         public CountTestResult(){
@@ -338,9 +338,10 @@ public interface IAssessor {
         public CountTestResult(ETestCategories whichTest){
             m_whichTest = whichTest;
         }
-        public CountTestResult(double dblLowBound, double dblActualValue, double dblHighBound) {
-            m_dblActualValue = dblActualValue;
-            m_dblHighBound = dblHighBound;
+        public CountTestResult(long lngLowBound, long lngActualValue, long lngHighBound) {
+            m_lngLowBound = lngLowBound;
+            m_lngActualValue = lngActualValue;
+            m_lngHighBound = lngHighBound;
         }
 
         public CountTestResult(ETestCategories whichTest, CompilerConfig compilerConfig) {
@@ -355,11 +356,12 @@ public interface IAssessor {
         }
     
         public CountTestResult(ETestCategories whichTest, CompilerConfig compilerConfig,
-                          double dblLowBound, double dblActualValue, double dblHighBound) {
+                               long lngLowBound, long lngActualValue, long lngHighBound) {
             m_whichTest = whichTest;
             m_compilerConfig.copyFrom(compilerConfig);
-            m_dblActualValue = dblActualValue;
-            m_dblHighBound = dblHighBound;
+            m_lngLowBound = lngLowBound;
+            m_lngActualValue = lngActualValue;
+            m_lngHighBound = lngHighBound;
         }
     
         public CountTestResult(ETestCategories whichTest, EArchitecture architecture, ECompiler compiler, EOptimize optimize) {
@@ -370,53 +372,58 @@ public interface IAssessor {
         }
     
         public CountTestResult(ETestCategories whichTest, EArchitecture architecture, ECompiler compiler, EOptimize optimize,
-                          double dblLowBound, double dblActualValue, double dblHighBound) {
+                               long lngLowBound, long lngActualValue, long lngHighBound) {
             m_whichTest = whichTest;
             m_compilerConfig.architecture = architecture;
             m_compilerConfig.compiler = compiler;
             m_compilerConfig.optimization = optimize;
-            m_dblActualValue = dblActualValue;
-            m_dblHighBound = dblHighBound;
+            m_lngLowBound = lngLowBound;
+            m_lngActualValue = lngActualValue;
+            m_lngHighBound = lngHighBound;
         }
 
         public void copyFrom(CountTestResult rhs){
             super.copyFrom(rhs);
-            m_dblActualValue = rhs.m_dblActualValue;
-            m_dblHighBound = rhs.m_dblHighBound;
+            m_lngLowBound = rhs.m_lngLowBound;
+            m_lngActualValue = rhs.m_lngActualValue;
+            m_lngHighBound = rhs.m_lngHighBound;
         }
 
         @Override
         public double dblGetLowBound() {
-            return 0;
+            return m_lngLowBound;
         }
 
         @Override
         public double dblGetActualValue() {
-            return m_dblActualValue;
+            return m_lngActualValue;
         }
 
         @Override
         public double dblGetHighBound() {
-            return m_dblHighBound;
+            return m_lngHighBound;
         }
 
         @Override
         public double dblGetTarget() {
-            return m_dblHighBound;
+            return m_lngHighBound;
         }
 
-       public void setActualValue(double dblActualValue){
-            m_dblActualValue=dblActualValue;
+        public void setLowBound(long lngLowBound){
+            m_lngLowBound = lngLowBound;
         }
-        public void setHighBound(double dblHighBound){
-            m_dblHighBound=dblHighBound;
+        public void setActualValue(long lngActualValue){
+            m_lngActualValue=lngActualValue;
+        }
+        public void setHighBound(long lngHighBound){
+            m_lngHighBound=lngHighBound;
         }
 
         public void increaseActualValue(){
-            m_dblActualValue++;
+            m_lngActualValue++;
         }
         public void increaseHighBound(){
-            m_dblHighBound++;
+            m_lngHighBound++;
         }
 
         @Override
@@ -438,8 +445,9 @@ public interface IAssessor {
         public void aggregateValues(TestResult rhs) {
             if (rhs instanceof CountTestResult rh){
                 super.aggregateAbstractValues(rhs);
-                m_dblActualValue += rh.m_dblActualValue;
-                m_dblHighBound += rh.m_dblHighBound;
+                m_lngLowBound += rh.m_lngLowBound;
+                m_lngActualValue += rh.m_lngActualValue;
+                m_lngHighBound += rh.m_lngHighBound;
             }
         }
     }

--- a/src/main/java/nl/ou/debm/assessor/IAssessor.java
+++ b/src/main/java/nl/ou/debm/assessor/IAssessor.java
@@ -283,6 +283,9 @@ public interface IAssessor {
         public CountTestResult(CountTestResult rhs){
             copyFrom(rhs);
         }
+        public CountTestResult(ETestCategories whichTest){
+            m_whichTest = whichTest;
+        }
         public CountTestResult(double dblLowBound, double dblActualValue, double dblHighBound) {
             m_dblLowBound = dblLowBound;
             m_dblActualValue = dblActualValue;

--- a/src/main/java/nl/ou/debm/common/CodeMarker.java
+++ b/src/main/java/nl/ou/debm/common/CodeMarker.java
@@ -587,7 +587,7 @@ public abstract class CodeMarker {
     //Precompile regex patterns for all features
     static {
         for(var prefix : EFeaturePrefix.values()) {
-            _C_patterns.put(prefix, Pattern.compile(".+\\(\"(" + STRCODEMARKERGUID + prefix + ">>.+" + STRCHECKSUM + ".+)\"", Pattern.CASE_INSENSITIVE));
+            _C_patterns.put(prefix, Pattern.compile(".+\\([^\"]*\"(" + STRCODEMARKERGUID + prefix + ">>.+" + STRCHECKSUM + ".+)\"", Pattern.CASE_INSENSITIVE));
             _LLVM_patterns.put(prefix, Pattern.compile( "\"" + STRCODEMARKERGUID + prefix + ">>.+"  + STRCHECKSUM + ".+\\Q\\\\E00\"", java.util.regex.Pattern.CASE_INSENSITIVE));
         }
     }

--- a/src/main/java/nl/ou/debm/common/Misc.java
+++ b/src/main/java/nl/ou/debm/common/Misc.java
@@ -219,11 +219,22 @@ public class Misc {
      * @return  the promised nicely formatted percentage string
      */
     public static String strGetPercentage(double dblLowBound, double dblActualValue, double dblHighBound){
+        return String.format("%.2f", 100 * dblGetFraction(dblLowBound, dblActualValue, dblHighBound));
+    }
+
+    /**
+     * Calculate fraction: (actual - low) / (high - low). Returns 0 if high=low.
+     * @param dblLowBound     lowest possible value
+     * @param dblActualValue  actual value
+     * @param dblHighBound    highest possible value
+     * @return  fraction
+     */
+    public static double dblGetFraction(double dblLowBound, double dblActualValue, double dblHighBound){
         var margin = dblHighBound - dblLowBound;
         if(margin == 0) {
             margin = 100;
         }
-        return String.format("%.2f", 100 * dblActualValue / margin);
+        return (dblActualValue - dblLowBound) / margin;
     }
 
     /**
@@ -249,6 +260,11 @@ public class Misc {
         return o1.compareTo(o2);
     }
 
+    /**
+     * Calculate CRC16 for a string
+     * @param strInput Input for CRC calculation
+     * @return CRC16
+     */
     public static int iCalcCRC16(String strInput){
         // adapted from:
         // D00001275 Flexible & Interoperable Data Transfer (FIT) Protocol Rev 2.3.pdf
@@ -267,6 +283,13 @@ public class Misc {
 
     private static final int[] s_crcTable = {0x0000, 0xCC01, 0xD801, 0x1400, 0xF001, 0x3C00, 0x2800, 0xE401,
                                              0xA001, 0x6C00, 0x7800, 0xB401, 0x5000, 0x9C01, 0x8801, 0x4400};
+
+    /**
+     * Get next CRC-calculation
+     * @param crc_in last CRC-16
+     * @param c character to be processed
+     * @return new CRC-16
+     */
     private static int iGetNextCRC16(int crc_in, char c){
         int tmp = s_crcTable[crc_in &0xF];
         crc_in = (crc_in >> 4) & 0xFFF;

--- a/src/main/java/nl/ou/debm/common/feature1/LoopAssessor.java
+++ b/src/main/java/nl/ou/debm/common/feature1/LoopAssessor.java
@@ -15,16 +15,16 @@ public class LoopAssessor implements IAssessor  {
     }
 
     @Override
-    public List<SingleTestResult> GetTestResultsForSingleBinary(CodeInfo ci){
-        var tr = new SingleTestResult(ETestCategories.FEATURE1_AGGREGATED, ci.compilerConfig);
-        tr.dblLowBound=0;
-        tr.dblActualValue=15;
-        tr.dblHighBound=15;
+    public List<TestResult> GetTestResultsForSingleBinary(CodeInfo ci){
+        var tr = new CountTestResult(ETestCategories.FEATURE1_AGGREGATED, ci.compilerConfig);
+        tr.setLowBound(0);
+        tr.setActualValue(15);
+        tr.setHighBound(15);
 
         useWalker(ci);
         //useVisitor(ci);
 
-        final List<SingleTestResult> out = new ArrayList<>();
+        final List<TestResult> out = new ArrayList<>();
         out.add(tr);
         return out;
     }

--- a/src/main/java/nl/ou/debm/common/feature1/LoopTestResult.java
+++ b/src/main/java/nl/ou/debm/common/feature1/LoopTestResult.java
@@ -1,6 +1,0 @@
-package nl.ou.debm.common.feature1;
-
-public class LoopTestResult {
-
-
-}

--- a/src/main/java/nl/ou/debm/common/feature1/LoopTestResult.java
+++ b/src/main/java/nl/ou/debm/common/feature1/LoopTestResult.java
@@ -1,0 +1,6 @@
+package nl.ou.debm.common.feature1;
+
+public class LoopTestResult {
+
+
+}

--- a/src/main/java/nl/ou/debm/common/feature3/BooleanScore.java
+++ b/src/main/java/nl/ou/debm/common/feature3/BooleanScore.java
@@ -1,17 +1,87 @@
 package nl.ou.debm.common.feature3;
 
+import nl.ou.debm.assessor.ETestCategories;
+import nl.ou.debm.assessor.IAssessor;
 import nl.ou.debm.common.EArchitecture;
 
-public class BooleanScore {
+public class BooleanScore extends IAssessor.TestResult {
     public boolean expected;
     public boolean actual;
     public String name;
-    public EArchitecture architecture;
 
-    public BooleanScore(String name, EArchitecture architecture, boolean expected, boolean actual) {
-        this.name = name;
-        this.architecture = architecture;
+    //Used for aggregation
+    public int truePositives;
+    public int falsePositives;
+    public int trueNegatives;
+    public int falseNegatives;
+
+    public BooleanScore(){
+
+    }
+
+    public BooleanScore(ETestCategories whichTest, EArchitecture architecture, boolean expected, boolean actual) {
+        this.m_whichTest = whichTest;
         this.expected = expected;
         this.actual = actual;
+    }
+
+    @Override
+    public double dblGetLowBound() {
+        return 0;
+    }
+
+    @Override
+    public double dblGetActualValue() {
+        var precision = truePositives / (double)(truePositives + falsePositives);
+        var recall = truePositives / (double)(truePositives + falseNegatives);
+        return 2 * (precision * recall) / (precision + recall);
+    }
+
+    @Override
+    public double dblGetHighBound() {
+        return 1;
+    }
+
+    @Override
+    public double dblGetTarget() {
+        return 1;
+    }
+
+    @Override
+    public int iGetNumberOfDecimalsToBePrinted() {
+        return 3;
+    }
+
+    @Override
+    public IAssessor.TestResult getNewInstance() {
+        return new BooleanScore();
+    }
+
+    @Override
+    public IAssessor.TestResult makeCopy() {
+        var copy = new BooleanScore();
+        copy.actual = actual;
+        copy.expected = expected;
+        copy.name = name;
+        copy.m_whichTest = m_whichTest;
+        copy.truePositives = truePositives;
+        copy.trueNegatives = trueNegatives;
+        copy.falsePositives = falsePositives;
+        copy.falseNegatives = falseNegatives;
+        copy.m_compilerConfig.copyFrom(m_compilerConfig);
+        return copy;
+    }
+
+    @Override
+    public void aggregateValues(IAssessor.TestResult rhs) {
+        var score = (BooleanScore)rhs;
+        if(score.expected && score.actual)
+            truePositives++;
+        else if(!score.expected && score.actual)
+            falsePositives++;
+        else if(score.expected)
+            falseNegatives++;
+        else
+            trueNegatives++;
     }
 }

--- a/src/main/java/nl/ou/debm/common/feature3/Feature3CVisitor.java
+++ b/src/main/java/nl/ou/debm/common/feature3/Feature3CVisitor.java
@@ -36,9 +36,6 @@ public class Feature3CVisitor extends CBaseVisitor<Object> {
         ANTLR sees these lines as function definitions.
         Therefore, we return when no function body is found
         */
-        if(!isSourceVisitor){
-            System.out.println("test");
-        }
         if (ctx.compoundStatement() == null || ctx.compoundStatement().blockItemList() == null)
             return null;
 

--- a/src/main/java/nl/ou/debm/common/feature3/FunctionAssessor.java
+++ b/src/main/java/nl/ou/debm/common/feature3/FunctionAssessor.java
@@ -8,10 +8,7 @@ import nl.ou.debm.common.EFeaturePrefix;
 import nl.ou.debm.common.EOptimize;
 import nl.ou.debm.common.antlr.CParser;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class FunctionAssessor implements IAssessor {
 
@@ -55,16 +52,13 @@ public class FunctionAssessor implements IAssessor {
             return out;
         }
 
-        var result = new CountTestResult();
-        //We increase this on every check, and increase dblActualValue on every check pass
-        result.setHighBound(0);
-
         var sourceIsInCache = cachedSourceVisitors.containsKey(ci.cparser_org);
         var sourceCVisitor = cachedSourceVisitors.getOrDefault(ci.cparser_org, new Feature3CVisitor(true));
         var decompiledCVisitor = new Feature3CVisitor(false);
 
         if(!sourceIsInCache)
             sourceCVisitor.visit(ci.cparser_org.compilationUnit());
+        ci.cparser_dec.reset();
         decompiledCVisitor.visit(ci.cparser_dec.compilationUnit());
         if(!sourceIsInCache)
             cachedSourceVisitors.put(ci.cparser_org, sourceCVisitor);
@@ -92,7 +86,7 @@ public class FunctionAssessor implements IAssessor {
             decompiledFunction = decompiledMarker == null ? null : decompiledCVisitor.functions.get(decompiledMarker.functionId);
             if(decompiledMarker != null && !decompiledMarker.getFunctionName().equals(functionName))
                 decompiledFunction = null;
-            isTrue(functionName, ci.compilerConfig.architecture, foundFunctionsScores, decompiledFunction != null);
+            isTrue(functionName, ci.compilerConfig.architecture, ETestCategories.FEATURE3_FUNCTION_IDENTIFICATION, decompiledFunction != null);
 
             //8.3.2. CHECKING UNREACHABLE FUNCTIONS
             checkUnreachableFunctions(ci, sourceFunction, decompiledFunction);
@@ -113,49 +107,47 @@ public class FunctionAssessor implements IAssessor {
             //8.3.4. CHECKING NORMAL FUNCTION CALLS
             checkNormalFunctionCalls(ci, decFunctionsNamesByStartMarkerName, startMarkerNamesByDecompiledFunctionName, sourceFunction, decompiledFunction);
         }
-        for(var category : booleanScores.entrySet())
-            cumulateBooleanResults(ci.compilerConfig, category, out);
-        for(var category : numericScores.entrySet())
-            cumulateNumericResults(ci.compilerConfig, category, out);
+        out.addAll(booleanScores.values().stream().flatMap(Collection::stream).toList());
+        out.addAll(numericScores.values().stream().flatMap(Collection::stream).toList());
         return out;
     }
 
     private void checkReturnStatements(CodeInfo ci, FoundFunction sourceFunction, FoundFunction decompiledFunction) {
-        compare(sourceFunction.getName(), ci.compilerConfig.architecture, returnScores, sourceFunction.getNumberOfReturnStatements(), decompiledFunction.getNumberOfReturnStatements());
+        compare(sourceFunction.getName(), ci.compilerConfig.architecture, ETestCategories.FEATURE3_RETURN, sourceFunction.getNumberOfReturnStatements(), decompiledFunction.getNumberOfReturnStatements());
     }
 
     private void checkVariadicFunctions(CodeInfo ci, FoundFunction sourceFunction, FoundFunction decompiledFunction) {
         if(sourceFunction.isVariadic())
-            isTrue(sourceFunction.getName(), ci.compilerConfig.architecture, variadicScores, decompiledFunction.isVariadic());
+            isTrue(sourceFunction.getName(), ci.compilerConfig.architecture, ETestCategories.FEATURE3_VARIADIC_FUNCTION, decompiledFunction.isVariadic());
     }
 
     private void checkUnreachableFunctions(CodeInfo ci, FoundFunction sourceFunction, FoundFunction decompiledFunction) {
         //Update unreachable functions score when relevant
         if (sourceFunction.getCalledFromFunctions().size() == 0)
-            isTrue(sourceFunction.getName(), ci.compilerConfig.architecture, unreachableFunctionsScores, decompiledFunction != null);
+            isTrue(sourceFunction.getName(), ci.compilerConfig.architecture, ETestCategories.FEATURE3_UNREACHABLE_FUNCTION, decompiledFunction != null);
     }
 
     private void checkFunctionBoundaries(CodeInfo ci, FoundFunction sourceFunction, FoundFunction decompiledFunction) {
         var functionName = sourceFunction.getName();
         //Check start marker
         var decStartMarker = decompiledFunction.getMarkers().get(0);
-        isTrue(functionName, ci.compilerConfig.architecture, functionStartScores, decStartMarker.isAtFunctionStart);
+        isTrue(functionName, ci.compilerConfig.architecture, ETestCategories.FEATURE3_FUNCTION_START, decStartMarker.isAtFunctionStart);
 
-        compare(functionName, ci.compilerConfig.architecture, functionPrologueStatementsRate, sourceFunction.getNumberOfPrologueStatements(), decompiledFunction.getNumberOfPrologueStatements());
-        compare(functionName, ci.compilerConfig.architecture, functionEpilogueStatementsRate, sourceFunction.getNumberOfEpilogueStatements(), decompiledFunction.getNumberOfEpilogueStatements());
+        compare(functionName, ci.compilerConfig.architecture, ETestCategories.FEATURE3_FUNCTION_PROLOGUE_RATE, sourceFunction.getNumberOfPrologueStatements(), decompiledFunction.getNumberOfPrologueStatements());
+        compare(functionName, ci.compilerConfig.architecture, ETestCategories.FEATURE3_FUNCTION_EPILOGUE_RATE, sourceFunction.getNumberOfEpilogueStatements(), decompiledFunction.getNumberOfEpilogueStatements());
 
         //Check end marker
         var decEndMarker = decompiledFunction.getMarkers().get(decompiledFunction.getMarkers().size() - 1);
-        isTrue(functionName, ci.compilerConfig.architecture, functionEndScores, decEndMarker.isAtFunctionEnd);
+        isTrue(functionName, ci.compilerConfig.architecture, ETestCategories.FEATURE3_FUNCTION_END, decEndMarker.isAtFunctionEnd);
 
-        isTrue(functionName, ci.compilerConfig.architecture, perfectBoundariesScores, decompiledFunction.getMarkers().size() == 2);
+        isTrue(functionName, ci.compilerConfig.architecture, ETestCategories.FEATURE3_PERFECT_BOUNDARIES, decompiledFunction.getMarkers().size() == 2);
     }
 
     private void checkNormalFunctionCalls(CodeInfo ci, HashMap<String, String> decFunctionsNamesByStartMarkerName, HashMap<String, String> startMarkerNamesByDecompiledFunctionName, FoundFunction sourceFunction, FoundFunction decompiledFunction) {
         //Checking whether function is called the same amount of times
         var totalCalled = sourceFunction.getCalledFromFunctions().values().stream().reduce(0, Integer::sum);
         var decompiledTotalCalled = decompiledFunction.getCalledFromFunctions().values().stream().reduce(0, Integer::sum);
-        compare(sourceFunction.getName(), ci.compilerConfig.architecture, functionTotalCallScores, totalCalled, decompiledTotalCalled);
+        compare(sourceFunction.getName(), ci.compilerConfig.architecture, ETestCategories.FEATURE3_TOTAL_FUNCTION_CALLS, totalCalled, decompiledTotalCalled);
 
         //Checking function call sites per caller function
         var calledFromFunctions = sourceFunction.getCalledFromFunctions();
@@ -169,7 +161,7 @@ public class FunctionAssessor implements IAssessor {
                 continue;
             var decFunctionName = decFunctionsNamesByStartMarkerName.getOrDefault(calledFromFunction.getKey(), null);
             var decCalledFromFunction = decFunctionName == null ? 0 : decCalledFromFunctions.getOrDefault(decFunctionName, 0);
-            compare(sourceFunction.getName(), ci.compilerConfig.architecture, functionCallScores, calledFromFunction.getValue(), decCalledFromFunction);
+            compare(sourceFunction.getName(), ci.compilerConfig.architecture, ETestCategories.FEATURE3_FUNCTION_CALLS, calledFromFunction.getValue(), decCalledFromFunction);
         }
 
         //For every decompiled function call that is not in the source,
@@ -177,30 +169,20 @@ public class FunctionAssessor implements IAssessor {
         for (var decCalledFromFunction : decCalledFromFunctions.entrySet()) {
             var startMarkerName = startMarkerNamesByDecompiledFunctionName.getOrDefault(decCalledFromFunction.getKey(), null);
             if (startMarkerName == null || !calledFromFunctions.containsKey(startMarkerName))
-                compare(sourceFunction.getName(), ci.compilerConfig.architecture, functionCallScores, decCalledFromFunction.getValue(), 0);
+                compare(sourceFunction.getName(), ci.compilerConfig.architecture, ETestCategories.FEATURE3_FUNCTION_CALLS, decCalledFromFunction.getValue(), 0);
         }
     }
 
-    private void compare(String name, EArchitecture architecture, List<NumericScore> scores, int highBound, int actual) {
-        scores.add(new NumericScore(name, architecture, 0, highBound, actual));
+    private void compare(String name, EArchitecture architecture, ETestCategories category, int highBound, int actual) {
+        numericScores.get(category).add(new NumericScore(category, architecture, 0, highBound, actual));
     }
 
-    private void compare(String name, EArchitecture architecture, List<BooleanScore> scores, boolean expected, boolean actual) {
-        scores.add(new BooleanScore(name, architecture, expected, actual));
+    private void compare(String name, EArchitecture architecture, ETestCategories category, boolean expected, boolean actual) {
+        booleanScores.get(category).add(new BooleanScore(category, architecture, expected, actual));
     }
 
-    private void isTrue(String name, EArchitecture architecture, List<BooleanScore> scores, boolean actual) {
-        compare(name, architecture, scores, true, actual);
-    }
-
-    private void cumulateBooleanResults(CompilerConfig compilerConfig, Map.Entry<ETestCategories, List<BooleanScore>> scores, List<TestResult> out) {
-        for (var score : scores.getValue())
-            out.add(new CountTestResult(scores.getKey(), compilerConfig, 0, score.actual ? 1 : 0, 1));
-    }
-
-    private void cumulateNumericResults(CompilerConfig compilerConfig, Map.Entry<ETestCategories, List<NumericScore>> scores, List<TestResult> out) {
-        for (var score : scores.getValue())
-            out.add(new CountTestResult(scores.getKey(), compilerConfig, score.lowBound, score.actual, score.highBound));
+    private void isTrue(String name, EArchitecture architecture, ETestCategories category, boolean actual) {
+        compare(name, architecture, category, true, actual);
     }
 
     private interface Foo {

--- a/src/main/java/nl/ou/debm/common/feature3/NumericScore.java
+++ b/src/main/java/nl/ou/debm/common/feature3/NumericScore.java
@@ -1,20 +1,74 @@
 package nl.ou.debm.common.feature3;
 
+import nl.ou.debm.assessor.ETestCategories;
+import nl.ou.debm.assessor.IAssessor;
 import nl.ou.debm.common.EArchitecture;
 
-public class NumericScore {
+public class NumericScore extends IAssessor.TestResult {
     public int actual;
     public int lowBound;
     public int highBound;
     public String name;
     public EArchitecture architecture;
 
-    public NumericScore(String name, EArchitecture architecture, int lowBound, int highBound, int actual) {
-        this.name = name;
+    public NumericScore(){}
+
+    public NumericScore(ETestCategories whichTest, EArchitecture architecture, int lowBound, int highBound, int actual) {
+        this.m_whichTest = whichTest;
         this.architecture = architecture;
         this.lowBound = lowBound;
         this.highBound = highBound;
         this.actual = actual;
+    }
+
+    @Override
+    public double dblGetLowBound() {
+        return lowBound;
+    }
+
+    @Override
+    public double dblGetActualValue() {
+        return actual;
+    }
+
+    @Override
+    public double dblGetHighBound() {
+        return highBound;
+    }
+
+    @Override
+    public double dblGetTarget() {
+        return highBound;
+    }
+
+    @Override
+    public int iGetNumberOfDecimalsToBePrinted() {
+        return 1;
+    }
+
+    @Override
+    public IAssessor.TestResult getNewInstance() {
+        return new NumericScore();
+    }
+
+    @Override
+    public IAssessor.TestResult makeCopy() {
+        var copy = new NumericScore();
+        copy.actual = actual;
+        copy.highBound = highBound;
+        copy.lowBound = lowBound;
+        copy.name = name;
+        copy.m_whichTest = m_whichTest;
+        copy.m_compilerConfig.copyFrom(m_compilerConfig);
+        return copy;
+    }
+
+    @Override
+    public void aggregateValues(IAssessor.TestResult rhs) {
+        var score = (NumericScore)rhs;
+        highBound += score.highBound;
+        lowBound += score.lowBound;
+        actual += score.actual;
     }
 }
 

--- a/src/main/java/nl/ou/debm/test/AggregateAndReportTest.java
+++ b/src/main/java/nl/ou/debm/test/AggregateAndReportTest.java
@@ -36,7 +36,7 @@ public class AggregateAndReportTest {
         assertEquals(LIST_SIZE*100, (int)dblHighBoundSum(list));
 
         var list3 = new ArrayList<>(list);
-        list3.sort(new IAssessor.SingleTestResultComparator());
+        list3.sort(new IAssessor.TestResultComparator());
         showList(list3);
         var list2 = IAssessor.TestResult.aggregate(list);
         showList(list2);

--- a/src/main/java/nl/ou/debm/test/AggregateAndReportTest.java
+++ b/src/main/java/nl/ou/debm/test/AggregateAndReportTest.java
@@ -20,9 +20,9 @@ public class AggregateAndReportTest {
     public void Aggregate(){
         final int LIST_SIZE=16;
 
-        List<IAssessor.SingleTestResult> list = new ArrayList<>();
+        List<IAssessor.TestResult> list = new ArrayList<>();
         for (int i=0; i<LIST_SIZE; ++i){
-            list.add(new IAssessor.SingleTestResult(
+            list.add(new IAssessor.CountTestResult(
                     Misc.rnd.nextDouble() < .3 ? ETestCategories.FEATURE1_AGGREGATED : Misc.rnd.nextDouble() < .5 ? ETestCategories.FEATURE2_AGGREGATED : ETestCategories.FEATURE3_AGGREGATED,
                     Misc.rnd.nextDouble() < .5 ? EArchitecture.X64ARCH : EArchitecture.X86ARCH,
                     ECompiler.CLANG,
@@ -38,13 +38,13 @@ public class AggregateAndReportTest {
         var list3 = new ArrayList<>(list);
         list3.sort(new IAssessor.SingleTestResultComparator());
         showList(list3);
-        var list2 = IAssessor.SingleTestResult.aggregate(list);
+        var list2 = IAssessor.TestResult.aggregate(list);
         showList(list2);
-        var list4 = IAssessor.SingleTestResult.aggregateOverArchitecture(list);
+        var list4 = IAssessor.TestResult.aggregateOverArchitecture(list);
         showList(list4);
-        var list5 = IAssessor.SingleTestResult.aggregateOverCompiler(list);
+        var list5 = IAssessor.TestResult.aggregateOverCompiler(list);
         showList(list5);
-        var list6 = IAssessor.SingleTestResult.aggregateOverOptimization(list);
+        var list6 = IAssessor.TestResult.aggregateOverOptimization(list);
         showList(list6);
 
         assertEquals(LIST_SIZE, dblLowBoundSum(list));
@@ -76,24 +76,24 @@ public class AggregateAndReportTest {
         }
     }
 
-    private double dblLowBoundSum(List<IAssessor.SingleTestResult> list){
+    private double dblLowBoundSum(List<IAssessor.TestResult> list){
         double out=0;
         for (var item: list) {
-            out += item.dblLowBound;
+            out += item.dblGetLowBound();
         }
         return out;
     }
-    private double dblHighBoundSum(List<IAssessor.SingleTestResult> list){
+    private double dblHighBoundSum(List<IAssessor.TestResult> list){
         double out=0;
         for (var item: list) {
-            out += item.dblHighBound;
+            out += item.dblGetHighBound();
         }
         return out;
     }
-    private double dblActualSum(List<IAssessor.SingleTestResult> list){
+    private double dblActualSum(List<IAssessor.TestResult> list){
         double out=0;
         for (var item: list) {
-            out += item.dblActualValue;
+            out += item.dblGetActualValue();
         }
         return out;
     }

--- a/src/main/java/nl/ou/debm/test/AssessorTest.java
+++ b/src/main/java/nl/ou/debm/test/AssessorTest.java
@@ -74,7 +74,7 @@ public class AssessorTest {
 
         //Check for full score
         for (var testResult : results) {
-            assertEquals(testResult.dblHighBound, testResult.dblActualValue);
+            assertEquals(testResult.dblGetHighBound(), testResult.dblGetActualValue());
         }
     }
 }

--- a/src/main/java/nl/ou/debm/test/SingleTestResultTest.java
+++ b/src/main/java/nl/ou/debm/test/SingleTestResultTest.java
@@ -14,23 +14,23 @@ public class SingleTestResultTest
 {
     @Test
     void Basics(){
-        var s1 = new IAssessor.SingleTestResult();
-        var s2 = new IAssessor.SingleTestResult();
+        var s1 = new IAssessor.CountTestResult();
+        var s2 = new IAssessor.CountTestResult();
         assertEquals(s1,s2);
-        s1.dblActualValue=10; s1.dblHighBound=10;
+        s1.setActualValue(10); s1.setActualValue(10);
         assertEquals(s1,s2);
-        var s3 = new IAssessor.SingleTestResult(ETestCategories.FEATURE1_AGGREGATED, EArchitecture.X64ARCH, ECompiler.CLANG, EOptimize.OPTIMIZE,
+        var s3 = new IAssessor.CountTestResult(ETestCategories.FEATURE1_AGGREGATED, EArchitecture.X64ARCH, ECompiler.CLANG, EOptimize.OPTIMIZE,
                 0, 10, 15);
-        var s4 = new IAssessor.SingleTestResult(ETestCategories.FEATURE1_AGGREGATED, EArchitecture.X64ARCH, ECompiler.CLANG, EOptimize.OPTIMIZE,
+        var s4 = new IAssessor.CountTestResult(ETestCategories.FEATURE1_AGGREGATED, EArchitecture.X64ARCH, ECompiler.CLANG, EOptimize.OPTIMIZE,
                 0, 10, 15);
         assertEquals(s3,s4);
         assertNotEquals(s1,s4);
-        s3.compilerConfig.architecture=null;
+        s3.getCompilerConfig().architecture=null;
         assertNotEquals(s3,s4);
-        s4.compilerConfig.architecture=null;
+        s4.getCompilerConfig().architecture=null;
         assertEquals(s3,s4);
         assertEquals(0, s3.compareTo(s4));
-        s3.compilerConfig.architecture=EArchitecture.X86ARCH;
+        s3.getCompilerConfig().architecture=EArchitecture.X86ARCH;
         assertNotEquals(s3,s4);
         assertEquals(1, s3.compareTo(s4));
     }


### PR DESCRIPTION
**In short**
This refactors the class system for test results. Major change: abstract base class, flexible implementations (one added: CountTestResult). Minor changes (added comment, used the child class where the old (base) class was used.
**Major change: abstract base class for test results**
Keep any real test scores in an appropriate child class. The implementation of the abstract methods of the base class will give the report module access to them.
The base class keeps track of the test itself, the compiler configuration used, whether or not it was skipped (though this result is never really used - Reijer should carefully examine what to do with it when he implements the new system in his own feature) and the number of tests it is based upon. The latter is useful for aggregation.
The base class forces the presence of an aggregation method, where the results of another TestResult-object are added to this one. This enables the child class to aggregate in any way it wishes.
_Suggested recall/precision implementation_
Make a child class RecallTestResult with attributes like iNumberOfRealPositives, iNumberOfFalsePositives etc. For one test, set these to 0 or 1. Write a simple aggregation function (don't forget to call the base aggregation function, that takes care of the number of tests aggregation). Write a function that calculates the metric, something like double dblGetActualValue(){ return iNumberOfRealPositives/(iNumberOfRealPositives + iNumberOfFalsePositives); } (_note: I didn't read up on the exact definition of this metric, so take care not to just copy the example_). The low bound should return 0, the high bound should return 1. Target should also be 1. Set the number of decimals to be printed in the table to an appropriate value (I suggest 2). Don't forget fancy constructors. Look at CountTestResult for inspiration.
**Minor changes**
Some smoothing out in procedures that calculate fractions or make percentage strings, made the html table a bit more stylish. SingleTestResult renamed to TestResult, as the class may contain a whole set of (aggregated) test results.
Privatised all the attributes of TestResult and added accessors, as TestResult now has outgrown the original struct-idea.