### PR TITLE
Changed fraction calculation

### DIFF
--- a/src/main/java/nl/ou/debm/assessor/IAssessor.java
+++ b/src/main/java/nl/ou/debm/assessor/IAssessor.java
@@ -5,7 +5,6 @@ import nl.ou.debm.common.antlr.CLexer;
 import nl.ou.debm.common.antlr.CParser;
 import nl.ou.debm.common.antlr.LLVMIRLexer;
 import nl.ou.debm.common.antlr.LLVMIRParser;
-import nl.ou.debm.common.feature3.BooleanScore;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -444,14 +443,12 @@ public interface IAssessor {
 
         @Override
         public void aggregateValues(TestResult rhs) {
-            if (rhs instanceof CountTestResult rh){
-                super.aggregateAbstractValues(rhs);
-                m_lngLowBound += rh.m_lngLowBound;
-                m_lngActualValue += rh.m_lngActualValue;
-                m_lngHighBound += rh.m_lngHighBound;
-            }else{
-                super.aggregateAbstractValues(rhs);
-            }
+            assert rhs instanceof CountTestResult : "aggregating different types of test results";
+            super.aggregateAbstractValues(rhs);
+            var rh = (CountTestResult) rhs;
+            m_lngLowBound += rh.m_lngLowBound;
+            m_lngActualValue += rh.m_lngActualValue;
+            m_lngHighBound += rh.m_lngHighBound;
         }
     }
 

--- a/src/main/java/nl/ou/debm/common/Misc.java
+++ b/src/main/java/nl/ou/debm/common/Misc.java
@@ -216,6 +216,7 @@ public class Misc {
      * @param dblLowBound     lowest possible value
      * @param dblActualValue  actual value
      * @param dblHighBound    highest possible value
+     * @param dblTargetValue  target value
      * @return  the promised nicely formatted percentage string
      */
     public static String strGetPercentage(double dblLowBound, double dblActualValue, double dblHighBound, double dblTargetValue){
@@ -223,16 +224,42 @@ public class Misc {
     }
 
     /**
-     * Calculate fraction: (actual - low) / (high - low). Returns 0 if high=low.
+     * Calculate fraction. Return 1 if actual = target. Return 0 if actual is low bound or high bound.
      * @param dblLowBound     lowest possible value
      * @param dblActualValue  actual value
      * @param dblHighBound    highest possible value
+     * @param dblTargetValue  target value
      * @return  fraction
      */
     public static double dblGetFraction(double dblLowBound, double dblActualValue, double dblHighBound, double dblTargetValue){
-        var margin = dblHighBound - dblLowBound;
-        var diff = Math.abs(dblActualValue - dblTargetValue);
-        return 1 - (diff / margin);
+        // check inputs
+        assert dblLowBound <= dblHighBound : "Low bound is greater than high bound";
+        assert dblLowBound <= dblActualValue : "Actual value is smaller than low bound";
+        assert dblActualValue <= dblHighBound : "Actual value is greater than high bound";
+        assert dblLowBound <= dblTargetValue : "Target value is smaller than low bound";
+        assert dblTargetValue <= dblHighBound : "Target value is greater than high bound";
+        // return 1 if all is well
+        if (dblActualValue==dblTargetValue){
+            return 1;
+        }
+        // we do not need to consider the situation that low bound == high bound, because in that
+        // case, target and actual must also be low bound (and high bound), thus the function
+        // will have returned 1 by now
+
+
+        // return fraction in cases actual is below target
+        if (dblActualValue < dblTargetValue){
+            // returns 0 if actual==low bound
+            // returns (almost) 1 if actual is (almost) target
+            var margin = dblTargetValue - dblLowBound;
+            var diff = dblActualValue - dblLowBound;
+            return diff/margin;
+        }
+
+        // return fraction is cases actual is above target
+        var margin = dblHighBound - dblTargetValue;
+        var diff = dblHighBound - dblActualValue;
+        return diff/margin;
     }
 
     /**

--- a/src/main/java/nl/ou/debm/test/MiscTest.java
+++ b/src/main/java/nl/ou/debm/test/MiscTest.java
@@ -205,4 +205,27 @@ class MiscTest {
         assertEquals(40797, iCalcCRC16("dec'm rulez!"));
         assertEquals(26577, iCalcCRC16("JBC/JSC inc."));
     }
+
+    @Test
+    public void FractionTest(){
+        double low=10, high=30, target=25;
+
+        assertThrows(AssertionError.class, () -> { Misc.dblGetFraction(low, 9, high, target);  });
+        assertThrows(AssertionError.class, () -> { Misc.dblGetFraction(low, 31, high, target);  });
+        assertThrows(AssertionError.class, () -> { Misc.dblGetFraction(low, 15, high, 9);  });
+        assertThrows(AssertionError.class, () -> { Misc.dblGetFraction(low, 15, high, 31);  });
+        assertThrows(AssertionError.class, () -> { Misc.dblGetFraction(high, 15, low, target);  });
+
+        assertEquals(1, Misc.dblGetFraction(low, 25, high, target));
+        assertEquals((10.0/15.0), Misc.dblGetFraction(low, 20, high, target));
+        assertEquals((5.0/15.0), Misc.dblGetFraction(low, 15, high, target));
+        assertEquals((0.0/15.0), Misc.dblGetFraction(low, 10, high, target));
+        assertEquals((0.0/5.0), Misc.dblGetFraction(low, 30, high, target));
+        assertEquals((1.0/5.0), Misc.dblGetFraction(low, 29, high, target));
+        assertEquals((2.0/5.0), Misc.dblGetFraction(low, 28, high, target));
+        assertEquals((3.0/5.0), Misc.dblGetFraction(low, 27, high, target));
+        assertEquals((4.0/5.0), Misc.dblGetFraction(low, 26, high, target));
+
+
+    }
 }


### PR DESCRIPTION
Reijer changed the fraction calculation to base it on a difference from the target value. That is an improvement, but it does not reach 0, as it calculates the absolute difference from the target, divided by the entire margin high bound -/- low bound. If target is between low bound and high bound, the max difference for actual will never be the full margin.
New calculation fixes this.
First, it asserts its input: low must be <= high, target and actual must be between low and high.
If actual == target, 1 is returned.
If actual < target, a linear function is used, yielding 0 when actual == low and 1 when actual == target.
If actual > target, a linear function is used, yielding 0 when actual == high and 1 when actual == target.
Target does not have to lie exactly between high and low bounds.