### PR TITLE
Production version niceties

### DIFF
--- a/src/main/java/nl/ou/debm/assessor/Assessor.java
+++ b/src/main/java/nl/ou/debm/assessor/Assessor.java
@@ -84,6 +84,7 @@ public class Assessor {
 
         // get container number
         final int iContainerNumber = iGetContainerNumberToBeAssessed(iRequestedContainerNumber);
+        System.out.println("Selected container:   " + iContainerNumber);
 
         // get number of valid tests within container
         final int iNumberOfTests = iNumberOfValidTestsInContainer(iContainerNumber);

--- a/src/main/java/nl/ou/debm/assessor/Assessor.java
+++ b/src/main/java/nl/ou/debm/assessor/Assessor.java
@@ -22,6 +22,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import static nl.ou.debm.common.IOElements.*;
+import static nl.ou.debm.common.ProjectSettings.IDEFAULTNUMBEROFCONTAINERS;
 
 /*
 
@@ -66,7 +67,9 @@ public class Assessor {
         feature.add(new FunctionAssessor());
     }
 
-    public List<IAssessor.TestResult> RunTheTests(final String strContainersBaseFolder, final String strDecompileScript, final boolean allowMissingBinaries) throws Exception {
+    public List<IAssessor.TestResult> RunTheTests(final String strContainersBaseFolder, final String strDecompileScript,
+                                                  final int iRequestedContainerNumber,
+                                                  final boolean allowMissingBinaries) throws Exception {
         var reuseDecompilersOutput = false;
 
         // create list to be able to aggregate
@@ -81,7 +84,7 @@ public class Assessor {
         }
 
         // get container number
-        final int iContainerNumber = iGetContainerNumberToBeAssessed();
+        final int iContainerNumber = iGetContainerNumberToBeAssessed(iRequestedContainerNumber);
 
         // get number of valid tests within container
         final int iNumberOfTests = iNumberOfValidTestsInContainer(iContainerNumber);
@@ -209,13 +212,14 @@ public class Assessor {
 
     /**
      * Get the number of the container that is to be tested/assessed
+     * @param iInput anything below 0 or above 199 will select a random container number
      * @return  ID, ranging 0...199
      */
-    int iGetContainerNumberToBeAssessed(){
-        // TODO: Implement getting a container number from anywhere
-        //       (command line input, random something, whatever)
-        //       for now: just return 0 for test purposes
-        return 0;
+    int iGetContainerNumberToBeAssessed(int iInput){
+        if ((0<=iInput) && (iInput< IDEFAULTNUMBEROFCONTAINERS)){
+            return iInput;
+        }
+        return Misc.rnd.nextInt(IDEFAULTNUMBEROFCONTAINERS);
     }
 
     /**

--- a/src/main/java/nl/ou/debm/assessor/Assessor.java
+++ b/src/main/java/nl/ou/debm/assessor/Assessor.java
@@ -318,7 +318,7 @@ public class Assessor {
         List<IAssessor.TestResult> adaptedInput;
         if (bSortOutput){
             adaptedInput = new ArrayList<>(input);
-            input.sort(new IAssessor.TestResultComparator());
+            input.sort(new IAssessor.TestResultComparatorWithTestNumber());
         }
         else{
             adaptedInput = input;

--- a/src/main/java/nl/ou/debm/assessor/Assessor.java
+++ b/src/main/java/nl/ou/debm/assessor/Assessor.java
@@ -163,6 +163,8 @@ public class Assessor {
                         // read compiler LLVM output
                         codeinfo.llexer_org = new LLVMIRLexer(CharStreams.fromFileName(strLLVMFullFileName(iContainerNumber, finalITestNumber, config.architecture, config.compiler, config.optimization)));
                         codeinfo.lparser_org = new LLVMIRParser(new CommonTokenStream(codeinfo.llexer_org));
+                        // remember file name (which comes in handy for debugging)
+                        codeinfo.strDecompiledCFilename = strCDest;
                         // invoke all features
                         for (var f : feature) {
                             var testResult = f.GetTestResultsForSingleBinary(codeinfo);

--- a/src/main/java/nl/ou/debm/assessor/IAssessor.java
+++ b/src/main/java/nl/ou/debm/assessor/IAssessor.java
@@ -503,13 +503,14 @@ public interface IAssessor {
      * three parsers, one each for the original C, the original LLVM and the decompiled C.
      */
     class CodeInfo {
-        public CLexer clexer_dec;           // lexer of decompiled C
-        public CParser cparser_dec;         // parser of decompiled C
-        public CLexer clexer_org;           // lexer of original C
-        public CParser cparser_org;         // parser of original C
-        public LLVMIRLexer llexer_org;      // lexer of original LLVM-IR
-        public LLVMIRParser lparser_org;    // parser of original LLVM-IR
-        final public CompilerConfig compilerConfig = new CompilerConfig();   // compiler, optimization. architecture
+        /** lexer of decompiled C */                    public CLexer clexer_dec;
+        /** parser of decompiled C */                   public CParser cparser_dec;
+        /** lexer of original C */                      public CLexer clexer_org;
+        /**parser of original C */                      public CParser cparser_org;
+        /** lexer of original LLVM-IR */                public LLVMIRLexer llexer_org;
+        /** parser of original LLVM-IR */               public LLVMIRParser lparser_org;
+        /** compiler, optimization. architecture */     final public CompilerConfig compilerConfig = new CompilerConfig();
+        /** name of decompiled file */                  public String strDecompiledCFilename;
     }
 
     /**

--- a/src/main/java/nl/ou/debm/assessor/Main.java
+++ b/src/main/java/nl/ou/debm/assessor/Main.java
@@ -4,16 +4,36 @@ import nl.ou.debm.common.Environment;
 import nl.ou.debm.common.IOElements;
 import nl.ou.debm.common.Misc;
 
+import java.nio.file.Path;
+
 import static java.lang.System.exit;
+import static nl.ou.debm.assessor.Assessor.generateReport;
 
 public class Main {
 
     public static void main(String[] args) throws Exception {
+        // handle args
         var cli = new AssessorCLIParameters();
         handleCLIParameters(args, cli);
+        printProgramHeader();
+        System.out.println("Containers folder:    " + cli.strContainerSourceLocation);
+        System.out.println("Decompilation script: " + cli.strDecompilerScript);
+        System.out.print  ("Requested container:  ");
+        if (cli.iContainerToBeTested>=0) {
+            System.out.println(cli.iContainerToBeTested);
+        }
+        else {
+            System.out.println("randomly selected one");
+        }
 
+        // do the assessment
         var ass = new Assessor();
-        ass.RunTheTests(cli.strContainerSourceLocation, cli.strDecompilerScript, cli.iContainerToBeTested ,false);
+        var result = ass.RunTheTests(cli.strContainerSourceLocation, cli.strDecompilerScript, cli.iContainerToBeTested ,false);
+
+        // output results
+        var aggregated = IAssessor.TestResult.aggregate(result);
+        generateReport(aggregated, Path.of(cli.strContainerSourceLocation, "report.html").toString());
+
         //The JVM keeps running forever. It is not clear which thread causes this, but a workaround for now is a hard exit.
         System.exit(0);
     }

--- a/src/main/java/nl/ou/debm/assessor/Main.java
+++ b/src/main/java/nl/ou/debm/assessor/Main.java
@@ -1,18 +1,157 @@
 package nl.ou.debm.assessor;
 
 import nl.ou.debm.common.Environment;
+import nl.ou.debm.common.IOElements;
+import nl.ou.debm.common.Misc;
 
-import java.security.InvalidParameterException;
+import static java.lang.System.exit;
 
 public class Main {
 
     public static void main(String[] args) throws Exception {
-        if(args.length != 1)
-            throw new InvalidParameterException("Program can only be run with exactly one argument!");
+        var cli = new AssessorCLIParameters();
+        handleCLIParameters(args, cli);
 
         var ass = new Assessor();
-        ass.RunTheTests(Environment.containerBasePath, args[0], false);
+        ass.RunTheTests(cli.strContainerSourceLocation, cli.strDecompilerScript, cli.iContainerToBeTested ,false);
         //The JVM keeps running forever. It is not clear which thread causes this, but a workaround for now is a hard exit.
         System.exit(0);
     }
+
+    /**
+     * Class to exchange command line data
+     */
+    private static class AssessorCLIParameters{
+        public String strContainerSourceLocation = "";
+        public String strDecompilerScript = "";
+        public int iContainerToBeTested = -1;
+    }
+
+    /**
+     * Handle command line arguments. When completely empty: do defaults. Show help is requested.
+     * Exits program when errors are encountered or help is requested.
+     * @param args command line argument array as provided to main()-function
+     * @param cli output
+     */
+    private static void handleCLIParameters(String[] args, AssessorCLIParameters cli){
+        // show help if requested
+        String[] HELP = { "-h", "-help", "/h", "/help", "-?", "/?"};
+        for (var a : args){
+            for (var h : HELP){
+                if (a.trim().compareToIgnoreCase(h)==0){
+                    printHelp();
+                    exit(0);
+                }
+            }
+        }
+
+        final int ERROR = 0;
+
+        // check number of parameters
+        if (args.length>3){
+            printHelp();
+            System.err.println("Error: too many parameters (" + args.length + ")");
+            for (int p=0; p<args.length; p++){
+                System.err.println(p + ":" + args[p]);
+            }
+            exit(ERROR);
+        }
+
+        // check container folder
+        if (args.length<1){
+            // omitted --> error
+            printHelp();
+            System.err.println("Error: container folder omitted, but is a required parameter.");
+            exit(ERROR);
+        }
+        else {
+            // use default?
+            if (args[0].equals("*")){
+                cli.strContainerSourceLocation = Environment.containerBasePath;
+            }
+            else {
+                // use argument
+                cli.strContainerSourceLocation = IOElements.strAdaptPathToMatchFileSystemAndAddSeparator(args[0]);
+            }
+            if (!IOElements.bFolderExists(cli.strContainerSourceLocation)){
+                printHelp();
+                System.err.println("Error: container folder does not exist.");
+                exit(ERROR);
+            }
+        }
+
+        // check decompiler script
+        if (args.length<2){
+            // omitted --> error
+            printHelp();
+            System.err.println("Error: decompiler script omitted, but is a required parameter.");
+            exit(ERROR);
+        }
+        else {
+            if (!IOElements.bFileExists(args[1])){
+                printHelp();
+                System.err.println("Error: decompiler script not found.");
+                exit(ERROR);
+            }
+            cli.strDecompilerScript = args[1];
+        }
+
+        // which container is to be checked
+        if (args.length<3){
+            // omitted, use default
+            cli.iContainerToBeTested = -1; // a random container will be selected later on in the programm
+        }
+        else {
+            // try to interpret
+            long val = Misc.lngRobustStringToLong(args[2], Long.MIN_VALUE);
+            if (val == Long.MIN_VALUE){
+                printHelp();
+                System.err.println("Error: conversion to number failed for container to be tested (" + args[2] + ")" );
+                exit(ERROR);
+            }
+            if (val < 0 ){
+                printHelp();
+                System.err.println("Error: negative container number is not allowed (" + args[2] + "); omit arg if you want a random container");
+                exit(ERROR);
+            }
+            cli.iContainerToBeTested = (int)val;
+        }
+
+    }
+
+    /**
+     * Dump help text to stdout
+     */
+    private static void printHelp(){
+        // show help and be done.
+        printProgramHeader();
+        System.out.println(
+                "This software takes up to three parameters:\n" +
+                        "container_root_folder  -- location of the root folder where all the test containers are found\n" +
+                        "                          required parameter.\n" +
+                        "decompiler_script      -- full path to a script to invoke the decompiler. The script must accept two\n" +
+                        "                          parameters, the first being the binary to be decompiled, the second being\n" +
+                        "                          the file that must contain the C output after decompilation\n" +
+                        "                          required parameter.\n" +
+                        "container_to_be_tested -- container number to be tested. If omitted, a random container is selected\n" +
+                        "                          integer value expected, decimal number, optional parameter\n" +
+                        "\n" +
+                        "running with any of the following in the argument list will produce this help:\n" +
+                        "-h, -help, -?, /h, /help, /?, all case insensitive"
+                // we do not show the hidden * option for container folder in the help screen, as it is
+                // developer specific
+        );
+    }
+
+    private static void printProgramHeader(){
+        System.out.println(
+                        "deb'm assessor\n" +
+                        "==============\n" +
+                        "\n" +
+                        "(c) 2023/2024 Jaap van den Bos, Kesava van Gelder, Reijer Klaasse\n");
+
+    }
+
+
+
 }

--- a/src/main/java/nl/ou/debm/common/Environment.java
+++ b/src/main/java/nl/ou/debm/common/Environment.java
@@ -8,6 +8,8 @@ public class Environment {
     public static EEnv actual;
     public static String containerBasePath;
     public static String decompilerPath; //where are the decompilers located
+    public final static String STRDEFAULTCONTAINERSROOTFOLDER = "containers";
+    public final static String STRDEFAULTSCRIPTSFOLDER = "scripts";
 
     public enum EEnv {
         KESAVA,
@@ -28,18 +30,15 @@ public class Environment {
             case KESAVA -> "C:\\OU\\IB9902, IB9906 - Afstudeerproject\\_repo\\_containers\\";
             case JAAP -> "/home/jaap/VAF/containers/";
             case REIJER -> "C:\\Users\\reije\\OneDrive\\Documenten\\Development\\c-program\\containers\\";
-            case DEFAULT -> "containers";
+            case DEFAULT -> STRDEFAULTCONTAINERSROOTFOLDER;
         };
 
         decompilerPath = switch (actual) {
             case KESAVA -> "C:\\OU\\IB9902, IB9906 - Afstudeerproject\\_repo\\_decompilers\\";
             case JAAP -> "/home/jaap/VAF/decompiler-benchmarking/scripts/";
             case REIJER -> "C:\\Users\\reije\\OneDrive\\Documenten\\Development\\c-program\\decompilers\\";
-            case DEFAULT -> "scripts";
+            case DEFAULT -> STRDEFAULTSCRIPTSFOLDER;
         };
-
-        System.out.println("using environment " + actual.toString());
-        System.out.println("using containerBasePath " + containerBasePath);
     }
 
     public static String strGetPerfectDecompilerScript(){

--- a/src/main/java/nl/ou/debm/common/IOElements.java
+++ b/src/main/java/nl/ou/debm/common/IOElements.java
@@ -6,6 +6,10 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
 
 import static nl.ou.debm.common.Misc.strGetNumberWithPrefixZeros;
 
@@ -217,5 +221,26 @@ public class IOElements {
 
         // if all went well, the directory is no more...
         return !Files.exists(folder);
+    }
+
+    /**
+     * Get sorted list of sub folders in a folder (no recursion, no separators)
+     * @param strPath input path
+     * @return sorted list of sub folders
+     */
+    public static List<String> getSubFolders(String strPath) {
+        // https://www.baeldung.com/java-list-directory-files
+
+        try (Stream<Path> stream = Files.list(Paths.get(strPath))) {
+            List<String> out = new ArrayList<>(stream
+                    .filter(Files::isDirectory)
+                    .map(Path::getFileName)
+                    .map(Path::toString)
+                    .toList());
+            Collections.sort(out);
+            return out;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/main/java/nl/ou/debm/common/Misc.java
+++ b/src/main/java/nl/ou/debm/common/Misc.java
@@ -447,17 +447,13 @@ public class Misc {
     public static IAssertion make;
 
     public static class RealAssertion implements IAssertion{
-
         @Override
         public void sure(boolean bExpression) {
             sure(bExpression, "");
         }
-
         @Override
         public void sure(boolean bExpression, String strErrorMessage) {
-            if (!bExpression){
-                throw new AssertionError(strErrorMessage);
-            }
+            if (!bExpression){ throw new AssertionError(strErrorMessage); }
         }
     }
 

--- a/src/main/java/nl/ou/debm/common/Misc.java
+++ b/src/main/java/nl/ou/debm/common/Misc.java
@@ -405,4 +405,67 @@ public class Misc {
         }
         return aboveLine/belowLine;
     }
+
+    /*
+        the assert keyword is very useful in Java, but it may be switched off with compiler options
+        as an alternative, we can use make.sure(), which does pretty much the same, but is controlled by this
+        static
+     */
+    static {
+        // use true is assertions should take place, and false if not
+        if (true){
+            make = new RealAssertion();
+        }
+        else{
+            make = new DummyAssertion();
+        }
+    }
+
+    /**
+     * interface for assertion class, so we can make a real class that actually does something, or a fake class
+     * to throw it all away
+     */
+    public interface IAssertion{
+        /**
+         * throw runtime exception when expression is false
+         * @param bExpression expression to be tested, must be true to have the program continue, when false: throws
+         *                    runtime exception
+         */
+        void sure(boolean bExpression);
+        /**
+         * throw runtime exception when expression is false
+         * @param bExpression expression to be tested, must be true to have the program continue, when false: throws
+         *                    runtime exception
+         * @param strErrorMessage error message to be included in exception
+         */
+        void sure(boolean bExpression, String strErrorMessage);
+    }
+
+    /**
+     * static assert object
+     */
+    public static IAssertion make;
+
+    public static class RealAssertion implements IAssertion{
+
+        @Override
+        public void sure(boolean bExpression) {
+            sure(bExpression, "");
+        }
+
+        @Override
+        public void sure(boolean bExpression, String strErrorMessage) {
+            if (!bExpression){
+                throw new AssertionError(strErrorMessage);
+            }
+        }
+    }
+
+    public static class DummyAssertion implements IAssertion{
+        @Override
+        public void sure(boolean bExpression) {}
+        @Override
+        public void sure(boolean bExpression, String strErrorMessage) {}
+    }
+
 }

--- a/src/main/java/nl/ou/debm/common/ProjectSettings.java
+++ b/src/main/java/nl/ou/debm/common/ProjectSettings.java
@@ -15,4 +15,6 @@ public class ProjectSettings {
     public static final int MAX_EXPRESSION_DEPTH = 5;
     public static final double CHANCE_OF_MULTIPLE_STATEMENTS=.01;
     public static final int MAX_MUTLIPLE_STATEMENTS=6;
-}
+
+    public final static int IDEFAULTNUMBEROFCONTAINERS = 200;
+    public final static int IDEFAULTTESTSPERCONTAINER = 200;}

--- a/src/main/java/nl/ou/debm/common/feature1/CountNoLimitTestResult.java
+++ b/src/main/java/nl/ou/debm/common/feature1/CountNoLimitTestResult.java
@@ -27,4 +27,31 @@ public class CountNoLimitTestResult extends IAssessor.CountTestResult {
     public void setHighBound(long lngHighBound) {
         // do nothing
     }
+
+    @Override
+    public IAssessor.TestResult getNewInstance() {
+        return new CountNoLimitTestResult();
+    }
+
+    @Override
+    public IAssessor.TestResult makeCopy() {
+        return new CountNoLimitTestResult(this);
+    }
+
+    public CountNoLimitTestResult(IAssessor.CountTestResult rhs) {
+        copyFrom(rhs);
+    }
+
+    @Override
+    public void copyFrom(IAssessor.TestResult rhs) {
+        super.copyAbstractValues(rhs);
+        assert rhs instanceof CountNoLimitTestResult;
+        var rhss = (CountNoLimitTestResult) rhs;
+        m_lngLowBound = rhss.m_lngLowBound;
+        m_lngActualValue = rhss.m_lngActualValue;
+    }
+
+    public CountNoLimitTestResult() {
+        super();
+    }
 }

--- a/src/main/java/nl/ou/debm/common/feature1/LoopCListener.java
+++ b/src/main/java/nl/ou/debm/common/feature1/LoopCListener.java
@@ -475,6 +475,7 @@ public class LoopCListener extends CBaseListener {
             }
             // copy
             var fli = m_fli.get(lngCurrentLoopID);
+            assert fli!=null : "CLID=" + lngCurrentLoopID;
             for (int ptr = iFirstElement ; ptr<iLastPlusOneElement ; ++ptr){
                 fli.m_lcm.add(purgedLoopCodeMarkerList.get(ptr));
             }
@@ -486,6 +487,7 @@ public class LoopCListener extends CBaseListener {
         // process sub lists
         for (var fliSet : m_fli.entrySet()){
             var fli = fliSet.getValue();
+            assert fli!=null : "fli==null";
             if (!fli.m_lcm.isEmpty()){
                 // loop code marker set should never be empty, but better be safe than sorry
                 //

--- a/src/main/java/nl/ou/debm/common/feature1/LoopCListener.java
+++ b/src/main/java/nl/ou/debm/common/feature1/LoopCListener.java
@@ -141,32 +141,21 @@ public class LoopCListener extends CBaseListener {
                    sum;
         }
     }
-    /** map of beauty scores, key = loopID */
-    private final Map<Long, LoopBeautyScore> m_beautyMap = new HashMap<>();
-    /** list of all code markers encountered in code, in the sequence that they are encountered */
-    private final List<LoopCodeMarker> m_loopcodemarkerList = new ArrayList<>();
+    /** map of beauty scores, key = loopID */   private final Map<Long, LoopBeautyScore> m_beautyMap = new HashMap<>();
+    /** list of all code markers encountered in code, in the sequence that they are encountered */  private final List<LoopCodeMarker> m_loopcodemarkerList = new ArrayList<>();
 
-    /** list of all test results */
-    private final List<IAssessor.TestResult> m_testResult = new ArrayList<>();
-    /** info on all loops found, key = loopID */
-    private final Map<Long, FoundLoopInfo> m_fli = new HashMap<>();
-    /** info on code markers in LLVM, key = code marker ID */
-    private Map<Long, CodeMarker.CodeMarkerLLVMInfo> m_llvmInfo;
-    /** map loop ID (key) to start code markerID (value) */
-    private final Map<Long, Long> m_LoopIDToStartMarkerCMID = new HashMap<>();
-    /** list of all loopID's from loops that are unrolled in the LLVM*/
-    private final List<Long> m_loopIDsUnrolledInLLVM = new ArrayList<>();
-    /** list of the ordinals of the tests performed, serves as index*/
-    private final List<Integer> m_testOridnalsList = new ArrayList<>();
-    /** most recent code marker encountered */
-    private LoopCodeMarker m_lastCodeMarker;
+    /** list of all test results */                             private final List<IAssessor.TestResult> m_testResult = new ArrayList<>();
+    /** info on all loops found, key = loopID */                private final Map<Long, FoundLoopInfo> m_fli = new HashMap<>();
+    /** info on code markers in LLVM, key = code marker ID */   private Map<Long, CodeMarker.CodeMarkerLLVMInfo> m_llvmInfo;
+    /** map loop ID (key) to start code markerID (value) */     private final Map<Long, Long> m_LoopIDToStartMarkerCMID = new HashMap<>();
+    /** list of all loopID's from loops that are unrolled in the LLVM*/ private final List<Long> m_loopIDsUnrolledInLLVM = new ArrayList<>();
+    /** list of the ordinals of the tests performed, serves as index*/  private final List<Integer> m_testOridnalsList = new ArrayList<>();
+    /** most recent code marker encountered */                  private LoopCodeMarker m_lastCodeMarker;
 
-    /** current function name */
-    private String m_strCurrentFunctionName;
-    /** keep track of loop start code markers, remove when loop end code marker is found*/
-    private final Stack<Long> m_currentLoopID = new Stack<>();
-    /** try to find a loop body statement as a first statement in a compound statement, null if nothing is searched */
-    private Long m_lngLookForThisLoopIDInCompoundStatement = null;
+    /** current function name */                                private String m_strCurrentFunctionName;
+    /** keep track of loop start code markers, remove when loop end code marker is found*/  private final Stack<Long> m_currentLoopID = new Stack<>();
+    /** try to find a loop body statement as a first statement in a compound statement, null if nothing is searched */  private Long m_lngLookForThisLoopIDInCompoundStatement = null;
+    /** current decoded C input file */                         private String m_strDecompiledCFile;
 
     /**
      * constructor
@@ -196,6 +185,9 @@ public class LoopCListener extends CBaseListener {
 
         // process LLVM info
         ProcessLLVM(ci);
+
+        // copy file name
+        m_strDecompiledCFile = ci.strDecompiledCFilename;
     }
 
     /**
@@ -475,11 +467,14 @@ public class LoopCListener extends CBaseListener {
             }
             // copy
             var fli = m_fli.get(lngCurrentLoopID);
-            assert fli!=null : "CLID=" + lngCurrentLoopID;
-            for (int ptr = iFirstElement ; ptr<iLastPlusOneElement ; ++ptr){
-                fli.m_lcm.add(purgedLoopCodeMarkerList.get(ptr));
+            if (fli!=null) {
+                // it is possible that a loop code marker is found containing a loop ID that is not
+                // in the m_fli-array. This happens when the start code marker is not in the decompiled C code
+                for (int ptr = iFirstElement; ptr < iLastPlusOneElement; ++ptr) {
+                    fli.m_lcm.add(purgedLoopCodeMarkerList.get(ptr));
+                }
+                fli.m_lcm.add(null);
             }
-            fli.m_lcm.add(null);
             // next set
             iFirstElement = iLastPlusOneElement;
         }
@@ -487,7 +482,6 @@ public class LoopCListener extends CBaseListener {
         // process sub lists
         for (var fliSet : m_fli.entrySet()){
             var fli = fliSet.getValue();
-            assert fli!=null : "fli==null";
             if (!fli.m_lcm.isEmpty()){
                 // loop code marker set should never be empty, but better be safe than sorry
                 //

--- a/src/main/java/nl/ou/debm/common/feature1/SchoolTestResult.java
+++ b/src/main/java/nl/ou/debm/common/feature1/SchoolTestResult.java
@@ -108,9 +108,11 @@ public class SchoolTestResult extends IAssessor.TestResult {
         setScore(dblSchoolScore);
     }
 
-    public void copyFrom(SchoolTestResult rhs){
-        super.copyFrom(rhs);
-        m_dblCumulativeScore = rhs.m_dblCumulativeScore;
-        m_dblMyScore = rhs.m_dblMyScore;
+    public void copyFrom(IAssessor.TestResult rhs){
+        super.copyAbstractValues(rhs);
+        assert rhs instanceof SchoolTestResult;
+        var rhss = (SchoolTestResult) rhs;
+        m_dblCumulativeScore = rhss.m_dblCumulativeScore;
+        m_dblMyScore = rhss.m_dblMyScore;
     }
 }

--- a/src/main/java/nl/ou/debm/common/feature3/F1Score.java
+++ b/src/main/java/nl/ou/debm/common/feature3/F1Score.java
@@ -63,6 +63,20 @@ public class F1Score extends IAssessor.TestResult {
     }
 
     @Override
+    public void copyFrom(IAssessor.TestResult rhs) {
+        assert rhs instanceof F1Score;
+        super.copyAbstractValues(rhs);
+        var rhss = (F1Score) rhs;
+        actual = rhss.actual;
+        expected = rhss.expected;
+        name = rhss.name;
+        truePositives = rhss.truePositives;
+        trueNegatives = rhss.trueNegatives;
+        falsePositives = rhss.falsePositives;
+        falseNegatives = rhss.falseNegatives;
+    }
+
+    @Override
     public IAssessor.TestResult getNewInstance() {
         return new F1Score();
     }
@@ -70,15 +84,7 @@ public class F1Score extends IAssessor.TestResult {
     @Override
     public IAssessor.TestResult makeCopy() {
         var copy = new F1Score();
-        copy.actual = actual;
-        copy.expected = expected;
-        copy.name = name;
-        copy.m_whichTest = m_whichTest;
-        copy.truePositives = truePositives;
-        copy.trueNegatives = trueNegatives;
-        copy.falsePositives = falsePositives;
-        copy.falseNegatives = falseNegatives;
-        copy.m_compilerConfig.copyFrom(m_compilerConfig);
+        copy.copyFrom(this);
         return copy;
     }
 

--- a/src/main/java/nl/ou/debm/common/feature3/NumericScore.java
+++ b/src/main/java/nl/ou/debm/common/feature3/NumericScore.java
@@ -54,6 +54,17 @@ public class NumericScore extends IAssessor.TestResult {
     }
 
     @Override
+    public void copyFrom(IAssessor.TestResult rhs) {
+        super.copyAbstractValues(rhs);
+        assert rhs instanceof NumericScore;
+        var rhss = (NumericScore) rhs;
+        actual = rhss.actual;
+        highBound = rhss.highBound;
+        lowBound = rhss.lowBound;
+        name = rhss.name;
+    }
+
+    @Override
     public IAssessor.TestResult getNewInstance() {
         return new NumericScore();
     }
@@ -61,12 +72,7 @@ public class NumericScore extends IAssessor.TestResult {
     @Override
     public IAssessor.TestResult makeCopy() {
         var copy = new NumericScore();
-        copy.actual = actual;
-        copy.highBound = highBound;
-        copy.lowBound = lowBound;
-        copy.name = name;
-        copy.m_whichTest = m_whichTest;
-        copy.m_compilerConfig.copyFrom(m_compilerConfig);
+        copy.copyFrom(this);
         return copy;
     }
 

--- a/src/main/java/nl/ou/debm/common/feature3/RecallScore.java
+++ b/src/main/java/nl/ou/debm/common/feature3/RecallScore.java
@@ -54,6 +54,18 @@ public class RecallScore extends IAssessor.TestResult {
     }
 
     @Override
+    public void copyFrom(IAssessor.TestResult rhs) {
+        super.copyAbstractValues(rhs);
+        assert rhs instanceof RecallScore;
+        var rhss = (RecallScore) rhs;
+        actual = rhss.actual;
+        expected = rhss.expected;
+        name = rhss.name;
+        relevantInstances = rhss.relevantInstances;
+        foundInstances = rhss.foundInstances;
+    }
+
+    @Override
     public IAssessor.TestResult getNewInstance() {
         return new RecallScore();
     }
@@ -61,13 +73,7 @@ public class RecallScore extends IAssessor.TestResult {
     @Override
     public IAssessor.TestResult makeCopy() {
         var copy = new RecallScore();
-        copy.actual = actual;
-        copy.expected = expected;
-        copy.name = name;
-        copy.m_whichTest = m_whichTest;
-        copy.relevantInstances = relevantInstances;
-        copy.foundInstances = foundInstances;
-        copy.m_compilerConfig.copyFrom(m_compilerConfig);
+        copy.copyFrom(this);
         return copy;
     }
 

--- a/src/main/java/nl/ou/debm/producer/Main.java
+++ b/src/main/java/nl/ou/debm/producer/Main.java
@@ -1,9 +1,6 @@
 package nl.ou.debm.producer;
 
-import nl.ou.debm.common.CompilerConfig;
-import nl.ou.debm.common.ECompiler;
-import nl.ou.debm.common.Environment;
-import nl.ou.debm.common.IOElements;
+import nl.ou.debm.common.*;
 import nl.ou.debm.common.task.ProcessTask;
 
 import java.io.File;
@@ -15,7 +12,12 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import static java.lang.System.exit;
+import static nl.ou.debm.common.ProjectSettings.IDEFAULTNUMBEROFCONTAINERS;
+import static nl.ou.debm.common.ProjectSettings.IDEFAULTTESTSPERCONTAINER;
+
 public class Main {
+
 
     // Creates files and returns a list of their names
     public static List<String> generate_source_code(String destination) {
@@ -171,12 +173,24 @@ public class Main {
         catch (Exception e) { throw new RuntimeException(e); }
     }
 
+
+
     public static void main(String[] args) throws Exception {
-        final var amountOfContainers = 1;
-        final var amountOfSources = 1;
+        // handle command line parameters --> handleCLIParameters exits on help or errors
+        var cli = new ProducerCLIParameters();
+        handleCLIParameters(args, cli);
+
+        // show program name & parameters
+        printProgramHeader();
+        System.out.println("Containers root folder: " + cli.strContainerDestinationLocation);
+        System.out.println("Number of containers:   " + cli.iNumberOfContainers);
+        System.out.println("Tests per container:    " + cli.iNumberOfTestsPerContainer);
+
+        final var amountOfContainers = cli.iNumberOfContainers;
+        final var amountOfSources = cli.iNumberOfTestsPerContainer;
 
         //1. Initialize folder structure
-        var containersFolder = new File(Environment.containerBasePath);
+        var containersFolder = new File(cli.strContainerDestinationLocation);
         if (!containersFolder.exists() && !containersFolder.mkdirs())
             throw new Exception("Unable to create containers folder");
 
@@ -236,6 +250,136 @@ public class Main {
         System.out.println("all tasks finished");
 
         //The JVM keeps running forever. It is not clear which thread causes this, but a workaround for now is a hard exit.
-        System.exit(0);
+        exit(0);
+    }
+
+    /**
+     * Class to exchange command line data
+     */
+    private static class ProducerCLIParameters{
+        public String strContainerDestinationLocation = "";
+        public int iNumberOfContainers = 0;
+        public int iNumberOfTestsPerContainer = 0;
+    }
+
+    /**
+     * Handle command line arguments. When completely empty: do defaults. Show help is requested.
+     * Exits program when errors are encountered or help is requested.
+     * @param args command line argument array as provided to main()-function
+     * @param cli output
+     */
+    private static void handleCLIParameters(String[] args, ProducerCLIParameters cli){
+        // show help if requested
+        String[] HELP = { "-h", "-help", "/h", "/help", "-?", "/?"};
+        for (var a : args){
+            for (var h : HELP){
+                if (a.trim().compareToIgnoreCase(h)==0){
+                    printHelp();
+                    exit(0);
+                }
+            }
+        }
+
+        final int ERROR = 1;
+
+        // check number of parameters
+        if (args.length>3){
+            printHelp();
+            System.err.println("Error: too many parameters (" + args.length + ")");
+            for (int p=0; p<args.length; p++){
+                System.err.println(p + ":" + args[p]);
+            }
+            exit(ERROR);
+        }
+
+        // check container folder
+        if (args.length<1){
+            // omitted, use current folder with default subfolder
+            cli.strContainerDestinationLocation = IOElements.strAdaptPathToMatchFileSystemAndAddSeparator(Environment.STRDEFAULTCONTAINERSROOTFOLDER);
+        }
+        else {
+            // use default?
+            if (args[0].equals("*")){
+                cli.strContainerDestinationLocation = Environment.containerBasePath;
+            }
+            else {
+                // use argument
+                cli.strContainerDestinationLocation = IOElements.strAdaptPathToMatchFileSystemAndAddSeparator(args[0]);
+            }
+        }
+
+        // check number of containers
+        if (args.length<2){
+            // omitted, use default
+            cli.iNumberOfContainers= IDEFAULTNUMBEROFCONTAINERS;
+        }
+        else {
+            // try to interpret
+            long val = Misc.lngRobustStringToLong(args[1], Long.MIN_VALUE);
+            if (val == Long.MIN_VALUE){
+                printHelp();
+                System.err.println("Error: conversion to number failed for number of containers (" + args[1] + ")" );
+                exit(ERROR);
+            }
+            if (val <= 0 ){
+                printHelp();
+                System.err.println("Error: number of containers must at least be 1 (" + args[1] + ")");
+                exit(ERROR);
+            }
+            cli.iNumberOfContainers = (int)val;
+        }
+
+        // check tests per containers
+        if (args.length<3){
+            // omitted, use default
+            cli.iNumberOfTestsPerContainer= IDEFAULTTESTSPERCONTAINER;
+        }
+        else {
+            // try to interpret
+            long val = Misc.lngRobustStringToLong(args[2], Long.MIN_VALUE);
+            if (val == Long.MIN_VALUE){
+                printHelp();
+                System.err.println("Error: conversion to number failed for number of tests per containers (" + args[2] + ")" );
+                exit(ERROR);
+            }
+            if (val <= 0 ){
+                printHelp();
+                System.err.println("Error: number of containers must at least be 1 (" + args[2] + ")");
+                exit(ERROR);
+            }
+            cli.iNumberOfTestsPerContainer = (int)val;
+        }
+
+    }
+
+    /**
+     * Dump help text to stdout
+     */
+    private static void printHelp(){
+        // show help and be done.
+        printProgramHeader();
+        System.out.println(
+                "This software takes up to three parameters:\n" +
+                "container_root_folder     -- location of the root folder where all the test containers are put\n" +
+                "                             if omitted, subfolder 'containers' of current folder is used.\n" +
+                "number_of_containers      -- number of containers to be produced. If omitted, " + IDEFAULTNUMBEROFCONTAINERS + " containers will be made\n" +
+                "                             integer value expected, decimal number\n" +
+                "number_of_tests/container -- number of tests per container. If omitted, " + IDEFAULTTESTSPERCONTAINER + " tests will be made\n" +
+                "                             integer value expected, decimal number\n" +
+                "\n" +
+                "running with any of the following in the argument list will produce this help:\n" +
+                "-h, -help, -?, /h, /help, /?, all case insensitive"
+                // we do not show the hidden * option for container folder in the help screen, as it is
+                // developer specific
+        );
+    }
+
+    private static void printProgramHeader(){
+        System.out.println(
+                "deb'm producer\n" +
+                        "==============\n" +
+                        "\n" +
+                        "(c) 2023/2024 Jaap van den Bos, Kesava van Gelder, Reijer Klaasse\n");
+
     }
 }

--- a/src/main/java/nl/ou/debm/test/AggregateAndReportTest.java
+++ b/src/main/java/nl/ou/debm/test/AggregateAndReportTest.java
@@ -36,7 +36,7 @@ public class AggregateAndReportTest {
         assertEquals(LIST_SIZE*100, (int)dblHighBoundSum(list));
 
         var list3 = new ArrayList<>(list);
-        list3.sort(new IAssessor.TestResultComparator());
+        list3.sort(new IAssessor.TestResultComparatorWithTestNumber());
         showList(list3);
         var list2 = IAssessor.TestResult.aggregate(list);
         showList(list2);

--- a/src/main/java/nl/ou/debm/test/AssessorTest.java
+++ b/src/main/java/nl/ou/debm/test/AssessorTest.java
@@ -3,7 +3,6 @@ package nl.ou.debm.test;
 import nl.ou.debm.assessor.Assessor;
 import nl.ou.debm.common.Environment;
 import nl.ou.debm.common.IOElements;
-import nl.ou.debm.common.Misc;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -68,7 +67,7 @@ public class AssessorTest {
 
         //Run assessor with our temp container file and our perfect decompiler
         var ass = new Assessor();
-        var results = ass.RunTheTests(tempDir.toString(), strDecompileScript, true);
+        var results = ass.RunTheTests(tempDir.toString(), strDecompileScript, -1,true);
 
         // Remove temp dir
         IOElements.bFolderAndAllContentsDeletedOK(tempDir);


### PR DESCRIPTION
# In short
This commit elaborates on the ready-to-use-versions of the producer and assessor. Both require some input parameters and deserve some output.
# Producer
## parameters
The producer Main now takes 0...3 pars:
_/nothing/
container_location
container_location number_of_containers
container_location number_of_containers number_of_tests_per_container_
container_location defaults to the current folder + containers. **If you want to use your own default location** (as set in Environment), **use a \***
number_of_containers defaults to 200
number_of_tests_per_containers defaults to 200
If you use something like /? -? /help etc., help is shown on stdout.
Parameters are checked, in case of trouble, help is shown on stdout and an errormessage on stderr.
## Output
The producers starts with stating it's alive by showing its name and a copyright notice. If it starts working, it shows its inputs, so you can check that it understood you correctly.
# Assessor
## parameters
The assessor now takes 2...3 pars:
_container_location decompilation_script
container_location decompilation_script container_to_be_tested_
container_location: _see above_
decompilation_script: use full path to your script
container_to_be_tested: set container manually, otherwise it selects a container randomly
If you use something like /? -? /help etc., help is shown on stdout.
Parameters are checked, in case of trouble, help is shown on stdout and an errormessage on stderr.
## Output
The assessor starts with stating it's alive by showing its name and a copyright notice. If it starts working, it shows its inputs, so you can check that it understood you correctly.
# TestResult copy mechanism
Old situation: abstract class contains protected base copy function
New situation: abstract class contains protected base copy function, but with a different name **plus it contains an abstract void copyFrom()** which forces each subclass writer to think of implementing the copy routine.
I've adapted all subclasses, **but Reijer: please double check yours!**
# Other (technical) changes
- the report generating call is moved from RunTheTests to Main(). RunTheTests returns the test set in usable (=set of objects) way. The conversion to a html-report is a next step and not an intended side-effect of RunTheTests.
- Environment: put defaults in constants (needed them elsewhere too)
- IOElements: added function to return a sorted list of subfolders
- Misc: added assertation code that can be switched on or off by code. I used it to debug while writing this PR's code, because normal assertations seemed not to be executed all the time (or I lost their output in some way)
- CodeInfo: field for the input file name, very useful when debugging
- Bugfix in feature 1 CListener
- Bugfix in instantiation of CountNoLimitTestResult