### PR TITLE
XML output added

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ANTLRGenerationPreferences">
     <option name="perGrammarGenerationSettings">
@@ -56,6 +57,9 @@
     </option>
   </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="ProjectResources">
+    <resource url="https://raw.githubusercontent.com/reijer-dev/decompiler-benchmarking/master/xml/output.dtd" location="$PROJECT_DIR$/xml/output.dtd" />
+  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_18" default="true" project-jdk-name="18" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>

--- a/README.md
+++ b/README.md
@@ -111,38 +111,14 @@ advise you to use those.
 ...read this:
 
 #### Arguments
-Invoke the producer from command line in your local Java environment.
-The producer Main takes 0...3 arguments:  
-_0: /no arguments/  
-1: container_location  
-2: container_location number_of_containers  
-3: container_location number_of_containers number_of_tests_per_container_
-- container_location defaults to the [current folder]/containers. During 
-development, we all three had our own default location that we set in the 
-Environment class. You may add yours and use a \* in stead of a full 
-location, in which case your environmental default will be used.
-- number_of_containers defaults to 50 if omitted
-- number_of_tests_per_containers defaults to 50 if omitted
-- argument are checked and in case of trouble, help is shown on stdout 
-  and an error message on stderr.
-- if any of the arguments is /h -h /help -help /? -?, help is shown on stdout. 
+Invoke the producer from command line in your local Java environment. Use -h,
+/h, -help, /help, -? or /? to get argument details.
 
 # Using the assessor
 
 ### Assessor arguments
-The assessor now takes 2 or 3 arguments:  
-_2: container_location decompilation_script  
-3: container_location decompilation_script container_to_be_tested_
-- container_location: _see above_
-- decompilation_script: use full path to your decompilation script. This 
-  script must take two arguments, the first being the full path to the 
-  binary to be decompiled, the second being the full path to a file that 
-  must contain the decompiled c output
-- container_to_be_tested: set container manually, otherwise it selects a 
-  container randomly
-- argument are checked and in case of trouble, help is shown on stdout
-  and an error message on stderr.
-- if any of the arguments is /h -h /help -help /? -?, help is shown on stdout.
+Invoke the assessor from command line in your local Java environment. Use -h,
+/h, -help, /help, -? or /? to get argument details.
 
 # Adding a test feature
 

--- a/src/main/java/nl/ou/debm/assessor/Assessor.java
+++ b/src/main/java/nl/ou/debm/assessor/Assessor.java
@@ -295,8 +295,8 @@ public class Assessor {
      * @param input  list of all the presented test results
      * @param strHTMLOutputFile  target file
      */
-    public static void generateReport(List<IAssessor.TestResult> input, String strHTMLOutputFile, boolean bAddTestColumns) {
-        generateReport(new HashMap<String, String>(), input, strHTMLOutputFile, bAddTestColumns);
+    public static void generateHTMLReport(List<IAssessor.TestResult> input, String strHTMLOutputFile, boolean bAddTestColumns) {
+        generateHTMLReport(new HashMap<String, String>(), input, strHTMLOutputFile, bAddTestColumns);
     }
 
     /**
@@ -339,8 +339,8 @@ public class Assessor {
      * @param bSortOutput if true, output is sorted per test/arch/compiler/opt
      * @param strHTMLOutputFile the file to which the output must be written
      */
-    public static void generateReport(Map<String, String> pars, List<IAssessor.TestResult> input, String strHTMLOutputFile, boolean bSortOutput, boolean bAddTestColumns){
-        StringBuilder sb_t = generateReport(pars, input, bSortOutput, bAddTestColumns);
+    public static void generateHTMLReport(Map<String, String> pars, List<IAssessor.TestResult> input, String strHTMLOutputFile, boolean bSortOutput, boolean bAddTestColumns){
+        StringBuilder sb_t = generateHTMLReport(pars, input, bSortOutput, bAddTestColumns);
         StringBuilder sb_h = new StringBuilder(), sb_f = new StringBuilder();
         getHTMLHeaderAndFooter(sb_h, sb_f);
         sb_h.append(sb_t).append(sb_f);
@@ -354,8 +354,8 @@ public class Assessor {
          * @param pars   map of custom parameter list to be added as info before data table
          * @param strHTMLOutputFile  target file
          */
-    public static void generateReport(Map<String, String> pars, List<IAssessor.TestResult> input, String strHTMLOutputFile, boolean bAddTestColumns){
-        generateReport(pars, input, strHTMLOutputFile, true, bAddTestColumns);
+    public static void generateHTMLReport(Map<String, String> pars, List<IAssessor.TestResult> input, String strHTMLOutputFile, boolean bAddTestColumns){
+        generateHTMLReport(pars, input, strHTMLOutputFile, true, bAddTestColumns);
     }
 
     /**
@@ -366,8 +366,8 @@ public class Assessor {
      * @param pars   map of custom parameter list to be added as info before data table
      * @return HTML-table
      */
-    public static StringBuilder generateReport(Map<String, String> pars, List<IAssessor.TestResult> input, boolean bAddTestColumns){
-        return generateReport(pars, input, true, bAddTestColumns);
+    public static StringBuilder generateHTMLReport(Map<String, String> pars, List<IAssessor.TestResult> input, boolean bAddTestColumns){
+        return generateHTMLReport(pars, input, true, bAddTestColumns);
     }
 
     /**
@@ -380,8 +380,8 @@ public class Assessor {
      * @param bAddTestColumns if true, add column for every single test case and the std deviation
      * @return HTML-table
      */
-    public static StringBuilder generateReport(Map<String, String> pars, List<IAssessor.TestResult> input,
-                                               boolean bSortOutput, boolean bAddTestColumns){
+    public static StringBuilder generateHTMLReport(Map<String, String> pars, List<IAssessor.TestResult> input,
+                                                   boolean bSortOutput, boolean bAddTestColumns){
         // sort the lot?
         List<IAssessor.TestResult> adaptedInput;
         if (bSortOutput){
@@ -453,6 +453,100 @@ public class Assessor {
         // finalize output
         sb.append("</table>");
         return sb;
+    }
+
+    public static StringBuilder generateXMLReport(Map<String, String> pars, List<IAssessor.TestResult> input,
+                                                  boolean bSortOutput, boolean bAddTestColumns){
+        final String STRTABLEPROPERTY = "tableproperty";
+        final String STRPROPNAME = "propname";
+        final String STRPROPVALUE = "propvalue";
+
+
+        // sort the lot?
+        List<IAssessor.TestResult> adaptedInput;
+        if (bSortOutput){
+            adaptedInput = new ArrayList<>(input);
+            input.sort(new IAssessor.TestResultComparatorWithTestNumber());
+        }
+        else{
+            adaptedInput = input;
+        }
+
+        // initialize output
+        var sb = new StringBuilder();
+
+        // new table
+        sb.append("<table>");
+
+        // parameter table
+        if (!pars.isEmpty()){
+            for (var item : pars.entrySet()){
+                appendXMLStartTag(sb, STRTABLEPROPERTY);
+                appendXMLSingleValue(sb, STRPROPNAME, item.getKey());
+                appendXMLSingleValue(sb, STRPROPVALUE, item.getValue());
+                appendXMLEndTag(sb, STRTABLEPROPERTY);
+            }
+        }
+
+//        // data table initialization
+//        sb.append("<table>");
+//        sb.append("<tr style='text-align:center; font-weight: bold'><th>Description (unit)</th><th>Architecture</th><th>Compiler</th><th>Optimization</th><th>Min score</th><th>Actual score</th><th>Max score</th><th>Target score</th><th>% min/max</th><th># tests</th>");
+//        var maxTests = 0;
+//        if (bAddTestColumns) {
+//            maxTests = adaptedInput.stream().map(x -> x.getScoresPerTest().size()).max(Comparator.comparingInt(x -> x)).orElse(0);
+//            for (var i = 0; i < maxTests; i++)
+//                sb.append("<th>Test ").append(i + 1).append("</th>");
+//            sb.append("<th>Standard deviation</th></tr>");
+//        }
+//
+//        // fill data table
+//        var evenRow = true;
+//        ETestCategories currentTestCategory = null;
+//        for (var item : adaptedInput){
+//            sb.append("<tr><td>");
+//            if(currentTestCategory != item.getWhichTest())
+//                sb.append(item.getWhichTest().strTestDescription()).append(" (").append(item.getWhichTest().strTestUnit()).append(")");
+//            sb.append("</td>");
+//            appendCell(sb, evenRow, item.getArchitecture(), ETextAlign.CENTER, ETextColour.BLACK, 0);
+//            appendCell(sb, evenRow, item.getCompiler(), ETextAlign.CENTER, ETextColour.BLACK,0 );
+//            appendCell(sb, evenRow, item.getOptimization(), ETextAlign.CENTER, ETextColour.BLACK, 0);
+//            appendCell(sb, evenRow, item.dblGetLowBound(), ETextAlign.RIGHT, ETextColour.GREY, item.iGetNumberOfDecimalsToBePrinted());
+//            appendCell(sb, evenRow, item.dblGetActualValue(), ETextAlign.RIGHT, ETextColour.BLACK, item.iGetNumberOfDecimalsToBePrinted());
+//            appendCell(sb, evenRow, item.dblGetHighBound(), ETextAlign.RIGHT, ETextColour.GREY, item.iGetNumberOfDecimalsToBePrinted());
+//            appendCell(sb, evenRow, item.dblGetTarget(), ETextAlign.RIGHT, ETextColour.GREY, item.iGetNumberOfDecimalsToBePrinted());
+//            appendCell(sb, evenRow, item.strGetPercentage(), ETextAlign.RIGHT, ETextColour.GREY, -1);
+//            appendCell(sb, evenRow, item.iGetNumberOfTests(), ETextAlign.RIGHT, ETextColour.GREY, 0);
+//            if (bAddTestColumns) {
+//                for (var i = 0; i < maxTests; i++) {
+//                    if (i < item.getScoresPerTest().size())
+//                        appendCell(sb, evenRow, item.getScoresPerTest().get(i), ETextAlign.RIGHT, ETextColour.GREY, 2);
+//                    else
+//                        appendCell(sb, evenRow, "-", ETextAlign.LEFT, ETextColour.GREY, 2);
+//                }
+//                appendCell(sb, evenRow, item.dblGetStandardDeviation(), ETextAlign.RIGHT, ETextColour.BLACK, 2);
+//            }
+//            sb.append("</tr>");
+//            currentTestCategory = item.getWhichTest();
+//            evenRow = !evenRow;
+//        }
+//
+        // finalize output
+        sb.append("</table>");
+        return sb;
+    }
+
+    private static void appendXMLStartTag(StringBuilder sb, String strTag){
+        sb.append("<").append(strTag).append(">");
+    }
+
+    private static void appendXMLEndTag(StringBuilder sb, String strTag){
+        sb.append("</").append(strTag).append(">");
+    }
+
+    private static void appendXMLSingleValue(StringBuilder sb, String strTag, String strValue){
+        appendXMLStartTag(sb, strTag);
+        sb.append(strValue);
+        appendXMLEndTag(sb, strTag);
     }
 
     /** enum to store html cell text align values */

--- a/src/main/java/nl/ou/debm/assessor/Assessor.java
+++ b/src/main/java/nl/ou/debm/assessor/Assessor.java
@@ -402,16 +402,18 @@ public class Assessor {
         var sb = new StringBuilder();
 
         // parameter table
-        if (!pars.isEmpty()){
-            sb.append("<table>");
-            sb.append("<tr style='text-align:center; font-weight: bold'><th>Description</th><th>Value</th></tr>");
-            for (var item : pars.entrySet()){
-                sb.append("<tr>");
-                sb.append("<td>").append(item.getKey()).append("</td>");
-                sb.append("<td>").append(item.getValue()).append("</td>");
-                sb.append("</tr>");
+        if (pars!=null) {
+            if (!pars.isEmpty()) {
+                sb.append("<table>");
+                sb.append("<tr style='text-align:center; font-weight: bold'><th>Description</th><th>Value</th></tr>");
+                for (var item : pars.entrySet()) {
+                    sb.append("<tr>");
+                    sb.append("<td>").append(item.getKey()).append("</td>");
+                    sb.append("<td>").append(item.getValue()).append("</td>");
+                    sb.append("</tr>");
+                }
+                sb.append("</table>");
             }
-            sb.append("</table>");
         }
 
         // data table initialization
@@ -503,12 +505,14 @@ public class Assessor {
         sb.append("<table>");
 
         // parameter table
-        if (!pars.isEmpty()){
-            for (var item : pars.entrySet()){
-                appendXMLStartTag(sb, STRTABLEPROPERTY);
-                appendXMLSingleValue(sb, STRPROPNAME, item.getKey(), 0);
-                appendXMLSingleValue(sb, STRPROPVALUE, item.getValue(), 0);
-                appendXMLEndTag(sb, STRTABLEPROPERTY);
+        if (pars!=null){
+            if (!pars.isEmpty()) {
+                for (var item : pars.entrySet()) {
+                    appendXMLStartTag(sb, STRTABLEPROPERTY);
+                    appendXMLSingleValue(sb, STRPROPNAME, item.getKey(), 0);
+                    appendXMLSingleValue(sb, STRPROPVALUE, item.getValue(), 0);
+                    appendXMLEndTag(sb, STRTABLEPROPERTY);
+                }
             }
         }
 

--- a/src/main/java/nl/ou/debm/assessor/Assessor.java
+++ b/src/main/java/nl/ou/debm/assessor/Assessor.java
@@ -461,6 +461,14 @@ public class Assessor {
         return sb;
     }
 
+    public static void generateXMLReport(Map<String, String> pars, List<IAssessor.TestResult> input, String strXMLOutputFile, boolean bSortOutput){
+        StringBuilder sb_t = generateXMLReport(pars, input, bSortOutput);
+        StringBuilder sb_h = new StringBuilder(), sb_f = new StringBuilder();
+        getHTMLHeaderAndFooter(sb_h, sb_f);
+        sb_h.append(sb_t).append(sb_f);
+        IOElements.writeToFile(sb_h, strXMLOutputFile);
+    }
+
     public static StringBuilder generateXMLReport(Map<String, String> pars, List<IAssessor.TestResult> input, boolean bSortOutput){
         final String STRTABLEPROPERTY = "tableproperty";
         final String STRPROPNAME = "propname";

--- a/src/main/java/nl/ou/debm/assessor/Assessor.java
+++ b/src/main/java/nl/ou/debm/assessor/Assessor.java
@@ -307,12 +307,8 @@ public class Assessor {
      */
     public static void getHTMLHeaderAndFooter(StringBuilder sb_header, StringBuilder sb_footer){
         // header
-        if (sb_header==null){
-            sb_header = new StringBuilder();
-        }
-        else {
-            sb_header.setLength(0);
-        }
+        assert sb_header!=null;
+        sb_header.setLength(0);
         sb_header.append("<html>");
         sb_header.append("<head>");
         sb_header.append("<style>");
@@ -322,13 +318,23 @@ public class Assessor {
         sb_header.append("<body>");
 
         // footer
-        if (sb_footer==null){
-            sb_footer = new StringBuilder();
-        }
-        else {
-            sb_footer.setLength(0);
-        }
+        assert sb_footer!=null;
+        sb_footer.setLength(0);
         sb_footer.append("</body></html>");
+    }
+
+    public static void getXMLHeaderAndFooter(StringBuilder sb_header, StringBuilder sb_footer){
+        // header
+        assert sb_header!=null;
+        sb_header.setLength(0);
+        sb_header.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        sb_header.append("<!DOCTYPE html PUBLIC \"-//DEBM//EN\" \"https://raw.githubusercontent.com/reijer-dev/decompiler-benchmarking/master/xml/output.dtd\">");
+        sb_header.append("<debm xmlns=\"https://raw.githubusercontent.com/reijer-dev/decompiler-benchmarking/master/xml/output.dtd\">");
+
+        // footer
+        assert sb_footer!=null;
+        sb_footer.setLength(0);
+        sb_footer.append("</debm>");
     }
 
     /**
@@ -455,12 +461,22 @@ public class Assessor {
         return sb;
     }
 
-    public static StringBuilder generateXMLReport(Map<String, String> pars, List<IAssessor.TestResult> input,
-                                                  boolean bSortOutput, boolean bAddTestColumns){
+    public static StringBuilder generateXMLReport(Map<String, String> pars, List<IAssessor.TestResult> input, boolean bSortOutput){
         final String STRTABLEPROPERTY = "tableproperty";
         final String STRPROPNAME = "propname";
         final String STRPROPVALUE = "propvalue";
-
+        final String STRTESTRESULT = "testresult";
+        final String STRTESTID = "testid";
+        final String STRTESTDESC = "testdescription";
+        final String STRTESTUNIT = "testunit";
+        final String STRARCH = "architecture";
+        final String STRCOMP = "compiler";
+        final String STROPT = "optimization";
+        final String STRMIN = "minvalue";
+        final String STRACT = "actualvalue";
+        final String STRMAX = "maxvalue";
+        final String STRTAR = "targetvalue";
+        final String STRCNT = "testcount";
 
         // sort the lot?
         List<IAssessor.TestResult> adaptedInput;
@@ -482,54 +498,28 @@ public class Assessor {
         if (!pars.isEmpty()){
             for (var item : pars.entrySet()){
                 appendXMLStartTag(sb, STRTABLEPROPERTY);
-                appendXMLSingleValue(sb, STRPROPNAME, item.getKey());
-                appendXMLSingleValue(sb, STRPROPVALUE, item.getValue());
+                appendXMLSingleValue(sb, STRPROPNAME, item.getKey(), 0);
+                appendXMLSingleValue(sb, STRPROPVALUE, item.getValue(), 0);
                 appendXMLEndTag(sb, STRTABLEPROPERTY);
             }
         }
 
-//        // data table initialization
-//        sb.append("<table>");
-//        sb.append("<tr style='text-align:center; font-weight: bold'><th>Description (unit)</th><th>Architecture</th><th>Compiler</th><th>Optimization</th><th>Min score</th><th>Actual score</th><th>Max score</th><th>Target score</th><th>% min/max</th><th># tests</th>");
-//        var maxTests = 0;
-//        if (bAddTestColumns) {
-//            maxTests = adaptedInput.stream().map(x -> x.getScoresPerTest().size()).max(Comparator.comparingInt(x -> x)).orElse(0);
-//            for (var i = 0; i < maxTests; i++)
-//                sb.append("<th>Test ").append(i + 1).append("</th>");
-//            sb.append("<th>Standard deviation</th></tr>");
-//        }
-//
-//        // fill data table
-//        var evenRow = true;
-//        ETestCategories currentTestCategory = null;
-//        for (var item : adaptedInput){
-//            sb.append("<tr><td>");
-//            if(currentTestCategory != item.getWhichTest())
-//                sb.append(item.getWhichTest().strTestDescription()).append(" (").append(item.getWhichTest().strTestUnit()).append(")");
-//            sb.append("</td>");
-//            appendCell(sb, evenRow, item.getArchitecture(), ETextAlign.CENTER, ETextColour.BLACK, 0);
-//            appendCell(sb, evenRow, item.getCompiler(), ETextAlign.CENTER, ETextColour.BLACK,0 );
-//            appendCell(sb, evenRow, item.getOptimization(), ETextAlign.CENTER, ETextColour.BLACK, 0);
-//            appendCell(sb, evenRow, item.dblGetLowBound(), ETextAlign.RIGHT, ETextColour.GREY, item.iGetNumberOfDecimalsToBePrinted());
-//            appendCell(sb, evenRow, item.dblGetActualValue(), ETextAlign.RIGHT, ETextColour.BLACK, item.iGetNumberOfDecimalsToBePrinted());
-//            appendCell(sb, evenRow, item.dblGetHighBound(), ETextAlign.RIGHT, ETextColour.GREY, item.iGetNumberOfDecimalsToBePrinted());
-//            appendCell(sb, evenRow, item.dblGetTarget(), ETextAlign.RIGHT, ETextColour.GREY, item.iGetNumberOfDecimalsToBePrinted());
-//            appendCell(sb, evenRow, item.strGetPercentage(), ETextAlign.RIGHT, ETextColour.GREY, -1);
-//            appendCell(sb, evenRow, item.iGetNumberOfTests(), ETextAlign.RIGHT, ETextColour.GREY, 0);
-//            if (bAddTestColumns) {
-//                for (var i = 0; i < maxTests; i++) {
-//                    if (i < item.getScoresPerTest().size())
-//                        appendCell(sb, evenRow, item.getScoresPerTest().get(i), ETextAlign.RIGHT, ETextColour.GREY, 2);
-//                    else
-//                        appendCell(sb, evenRow, "-", ETextAlign.LEFT, ETextColour.GREY, 2);
-//                }
-//                appendCell(sb, evenRow, item.dblGetStandardDeviation(), ETextAlign.RIGHT, ETextColour.BLACK, 2);
-//            }
-//            sb.append("</tr>");
-//            currentTestCategory = item.getWhichTest();
-//            evenRow = !evenRow;
-//        }
-//
+        // fill data table
+        for (var item : adaptedInput) {
+            appendXMLStartTag(sb, STRTESTRESULT);
+            appendXMLSingleValue(sb, STRTESTID, item.getWhichTest().lngUniversalIdentifier(), 0);
+            appendXMLSingleValue(sb, STRTESTDESC, item.getWhichTest().strTestDescription(), 0);
+            appendXMLSingleValue(sb, STRTESTUNIT, item.getWhichTest().strTestUnit(), 0);
+            appendXMLSingleValue(sb, STRARCH, item.getArchitecture(),0);
+            appendXMLSingleValue(sb, STRCOMP, item.getCompiler(), 0);
+            appendXMLSingleValue(sb, STROPT, item.getOptimization(),0 );
+            appendXMLSingleValue(sb, STRMIN, item.dblGetLowBound(), item.iGetNumberOfDecimalsToBePrinted());
+            appendXMLSingleValue(sb, STRMAX, item.dblGetHighBound(), item.iGetNumberOfDecimalsToBePrinted());
+            appendXMLSingleValue(sb, STRACT, item.dblGetActualValue(), item.iGetNumberOfDecimalsToBePrinted());
+            appendXMLSingleValue(sb, STRTAR, item.dblGetTarget(), item.iGetNumberOfDecimalsToBePrinted());
+            appendXMLSingleValue(sb, STRCNT, item.iGetNumberOfTests(), 0);
+            appendXMLEndTag(sb, STRTESTRESULT);
+        }
         // finalize output
         sb.append("</table>");
         return sb;
@@ -543,9 +533,9 @@ public class Assessor {
         sb.append("</").append(strTag).append(">");
     }
 
-    private static void appendXMLSingleValue(StringBuilder sb, String strTag, String strValue){
+    private static void appendXMLSingleValue(StringBuilder sb, String strTag, Object oValue, int iNumberOfDecimals){
         appendXMLStartTag(sb, strTag);
-        sb.append(strValue);
+        sb.append(strCellValue(oValue, iNumberOfDecimals));
         appendXMLEndTag(sb, strTag);
     }
 
@@ -599,6 +589,7 @@ public class Assessor {
      * @param oWhat  what is to be added
      * @param textAlign text alignment
      * @param textColour text color
+     * @param evenRow true if row is even (make shading pattern possible)
      * @param iNumberOfDecimals only used when printing a decimal value; number of decimals to be printed
      */
     private static void appendCell(StringBuilder sb, Boolean evenRow, Object oWhat, ETextAlign textAlign, ETextColour textColour, int iNumberOfDecimals){
@@ -607,6 +598,17 @@ public class Assessor {
         sb.append(textColour.strStyleProperty());
         sb.append((evenRow ? EBackgroundColour.WHITE : EBackgroundColour.GREY).strStyleProperty());
         sb.append("'>");
+        sb.append(strCellValue(oWhat, iNumberOfDecimals));
+        sb.append("</td>");
+    }
+
+    /**
+     * Get cell value
+     * @param oWhat the value to process
+     * @param iNumberOfDecimals number of decimals to use if it's a number
+     * @return neat string value; may be empty if oWhat is not recognized
+     */
+    private static String strCellValue(Object oWhat, int iNumberOfDecimals){
         String strWhat = null;
         if (oWhat!=null) {
             if (bIsNumeric(oWhat)) {
@@ -621,7 +623,7 @@ public class Assessor {
                     val = (double) ((Long) oWhat);
                 }
                 String strFormat = "%." + iNumberOfDecimals + "f";
-                sb.append(String.format(strFormat, val));
+                strWhat=String.format(Locale.ROOT, strFormat, val);
             } else if (oWhat instanceof String) {
                 strWhat = (String) oWhat;
             } else if (oWhat instanceof EArchitecture) {
@@ -632,10 +634,7 @@ public class Assessor {
                 strWhat = ((EOptimize) oWhat).strTableCode();
             }
         }
-        if (strWhat != null){
-            sb.append(strWhat);
-        }
-        sb.append("</td>");
+        return strWhat == null ? "" : strWhat;
     }
 
     private static boolean bIsNumeric(Object oWhat){

--- a/src/main/java/nl/ou/debm/assessor/ETestCategories.java
+++ b/src/main/java/nl/ou/debm/assessor/ETestCategories.java
@@ -6,7 +6,7 @@ package nl.ou.debm.assessor;
  * Use _AGGREGATED for final scores on your own feature<br>
  * Use child categories for details.<br>
  * <br>
- * Do not forget to add details in strTestDescription and strTestUnit.<br>
+ * Do not forget to add details in strTestDescription and strTestUnit, as well as an ID in lngUniversalIdentifier.<br>
  * <br>
  * As sorting of lists of test results is done using the enumeration as primary key,
  * take care where you put your new tests!
@@ -106,5 +106,47 @@ public enum ETestCategories {
             case FEATURE1_AGGREGATED, FEATURE2_AGGREGATED, FEATURE3_AGGREGATED, FEATURE4_AGGREGATED -> { return true;}
         }
         return false;
+    }
+
+    /**
+     * Get a unique ID for the metric.
+     * @return ID
+     */
+    public long lngUniversalIdentifier(){
+        // IMPORTANT!
+        // The idea of the ID is that the metric can be analysed by other computer code easily, as it comes up
+        // in the XML produced. DO NOT CHANGE METRIC ID"S PREVIOUSLY SET as it will hamper backward compatibility.
+        // That is also why we don't just return the ordinal number of the element in the ENUM.
+
+        long out = 0;
+        switch (this) {
+
+            case FEATURE1_AGGREGATED ->                         out = 100;
+            case FEATURE1_NUMBER_OF_LOOPS_GENERAL ->            out = 101;
+            case FEATURE1_NUMBER_OF_LOOPS_NOT_UNROLLED ->       out = 102;
+            case FEATURE1_NUMBER_OF_UNROLLED_LOOPS_AS_LOOP ->   out = 103;
+            case FEATURE1_LOOP_BEAUTY_SCORE_OVERALL ->          out = 104;
+            case FEATURE1_LOOP_BEAUTY_SCORE_NORMAL ->           out = 105;
+            case FEATURE1_LOOP_BEAUTY_SCORE_UNROLLED ->         out = 106;
+            case FEATURE1_TOTAL_NUMBER_OF_GOTOS ->              out = 107;
+            case FEATURE1_NUMBER_OF_UNWANTED_GOTOS ->           out = 108;
+
+            case FEATURE2_AGGREGATED ->                         out = 200;
+
+            case FEATURE3_AGGREGATED ->                         out = 300;
+            case FEATURE3_FUNCTION_IDENTIFICATION ->            out = 301;
+            case FEATURE3_FUNCTION_START ->                     out = 302;
+            case FEATURE3_FUNCTION_PROLOGUE_RATE ->             out = 303;
+            case FEATURE3_FUNCTION_EPILOGUE_RATE ->             out = 304;
+            case FEATURE3_FUNCTION_END ->                       out = 305;
+            case FEATURE3_RETURN ->                             out = 306;
+            case FEATURE3_UNREACHABLE_FUNCTION ->               out = 307;
+            case FEATURE3_FUNCTION_CALLS ->                     out = 308;
+            case FEATURE3_VARIADIC_FUNCTION ->                  out = 309;
+
+            case FEATURE4_AGGREGATED ->                         out = 400;
+            case FEATURE4_PARSER_ERRORS ->                      out = 401;
+        }
+        return out;
     }
 }

--- a/src/main/java/nl/ou/debm/assessor/Main.java
+++ b/src/main/java/nl/ou/debm/assessor/Main.java
@@ -83,7 +83,8 @@ public class Main {
         List<CommandLineUtils.ParameterDefinition> pmd = new ArrayList<>();
         pmd.add(new CommandLineUtils.ParameterDefinition(
                 "root_containers_folder",
-                "location of the root folder where all the test containers are located",
+                "location of the root folder where all the test containers are located. " +
+                        "If you use *, the default setting from the class Environment is used.",
                 new String[]{STRROOTCONTAINEROPTION, "/c="}, '1'
         ));
         pmd.add(new CommandLineUtils.ParameterDefinition(

--- a/src/main/java/nl/ou/debm/assessor/Main.java
+++ b/src/main/java/nl/ou/debm/assessor/Main.java
@@ -7,7 +7,7 @@ import nl.ou.debm.common.Misc;
 import java.nio.file.Path;
 
 import static java.lang.System.exit;
-import static nl.ou.debm.assessor.Assessor.generateReport;
+import static nl.ou.debm.assessor.Assessor.generateHTMLReport;
 
 public class Main {
 
@@ -32,7 +32,7 @@ public class Main {
 
         // output results
         var aggregated = IAssessor.TestResult.aggregate(result);
-        generateReport(aggregated, Path.of(cli.strContainerSourceLocation, "report.html").toString(), false);
+        generateHTMLReport(aggregated, Path.of(cli.strContainerSourceLocation, "report.html").toString(), false);
         System.out.println("========================================================================================");
         System.out.println("Done! Report in html written to " + Path.of(cli.strContainerSourceLocation, "report.html").toString());
 

--- a/src/main/java/nl/ou/debm/assessor/Main.java
+++ b/src/main/java/nl/ou/debm/assessor/Main.java
@@ -1,13 +1,17 @@
 package nl.ou.debm.assessor;
 
+import nl.ou.debm.common.CommandLineUtils;
 import nl.ou.debm.common.Environment;
 import nl.ou.debm.common.IOElements;
 import nl.ou.debm.common.Misc;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 
-import static java.lang.System.exit;
 import static nl.ou.debm.assessor.Assessor.generateHTMLReport;
+import static nl.ou.debm.assessor.Assessor.generateXMLReport;
+import static nl.ou.debm.common.CommandLineUtils.strGetParameterValue;
 
 public class Main {
 
@@ -15,7 +19,6 @@ public class Main {
         // handle args
         var cli = new AssessorCLIParameters();
         handleCLIParameters(args, cli);
-        printProgramHeader();
         System.out.println("Containers folder:    " + cli.strContainerSourceLocation);
         System.out.println("Decompilation script: " + cli.strDecompilerScript);
         System.out.print  ("Requested container:  ");
@@ -32,9 +35,20 @@ public class Main {
 
         // output results
         var aggregated = IAssessor.TestResult.aggregate(result);
-        generateHTMLReport(aggregated, Path.of(cli.strContainerSourceLocation, "report.html").toString(), false);
+        if (!cli.strHTMLOutput.isEmpty()){
+            generateHTMLReport(aggregated, cli.strHTMLOutput, false);
+        }
+        if (!cli.strXMLOutput.isEmpty()){
+            generateXMLReport(null, aggregated, cli.strXMLOutput, false);
+        }
         System.out.println("========================================================================================");
-        System.out.println("Done! Report in html written to " + Path.of(cli.strContainerSourceLocation, "report.html").toString());
+        System.out.println("Done!");
+        if (!cli.strHTMLOutput.isEmpty()){
+            System.out.println("HTML report written as: " + cli.strHTMLOutput);
+        }
+        if (!cli.strXMLOutput.isEmpty()){
+            System.out.println("XML report written as: " + cli.strXMLOutput);
+        }
 
         //The JVM keeps running forever. It is not clear which thread causes this, but a workaround for now is a hard exit.
         System.exit(0);
@@ -46,6 +60,8 @@ public class Main {
     private static class AssessorCLIParameters{
         public String strContainerSourceLocation = "";
         public String strDecompilerScript = "";
+        public String strHTMLOutput = "";
+        public String strXMLOutput = "";
         public int iContainerToBeTested = -1;
     }
 
@@ -56,124 +72,119 @@ public class Main {
      * @param cli output
      */
     private static void handleCLIParameters(String[] args, AssessorCLIParameters cli){
-        // show help if requested
-        String[] HELP = { "-h", "-help", "/h", "/help", "-?", "/?"};
-        for (var a : args){
-            for (var h : HELP){
-                if (a.trim().compareToIgnoreCase(h)==0){
-                    printHelp();
-                    exit(0);
-                }
-            }
-        }
+        // options
+        final String STRROOTCONTAINEROPTION = "-c=";
+        final String STRDECOMPILERSCRIPTOPTION = "-s=";
+        final String STRCONTAINERINDEXOPTION = "-i=";
+        final String STRHTMLOPTION = "-html=";
+        final String STRXMLOPTION = "-xml=";
 
-        final int ERROR = 0;
+        // set up basic interpretation parameters
+        List<CommandLineUtils.ParameterDefinition> pmd = new ArrayList<>();
+        pmd.add(new CommandLineUtils.ParameterDefinition(
+                "root_containers_folder",
+                "location of the root folder where all the test containers are located",
+                new String[]{STRROOTCONTAINEROPTION, "/c="}, '1'
+        ));
+        pmd.add(new CommandLineUtils.ParameterDefinition(
+                "decompiler_script",
+                "full path to a script to invoke the decompiler. The script must accept two " +
+                        "parameters, the first being the binary to be decompiled, the second being " +
+                        "the file that must contain the C output after decompilation",
+                new String[]{STRDECOMPILERSCRIPTOPTION, "/s="}, '1'
+        ));
+        pmd.add(new CommandLineUtils.ParameterDefinition(
+                "container_to_be_tested",
+                "container index to be tested. If omitted, a random container is selected. " +
+                        "Integer value expected, decimal number",
+                new String[]{STRCONTAINERINDEXOPTION, "/i="}, '?'
+        ));
+        pmd.add(new CommandLineUtils.ParameterDefinition(
+                "html_output",
+                "the assessor's results will be written in html to this file. If both html and" +
+                        "xml output options are omitted, a default html filename will be used.",
+                new String[]{STRHTMLOPTION, "/html="}, '?'
+        ));
+        pmd.add(new CommandLineUtils.ParameterDefinition(
+                "xml_output",
+                "the assessor's results will be written in xml to this file.",
+                new String[]{STRXMLOPTION, "/xml="}, '?'
+        ));
+        // set up info
+        var me = new CommandLineUtils("deb'm assessor",
+                "(c) 2023/2024 Jaap van den Bos, Kesava van Gelder, Reijer Klaasse",
+                pmd);
+        me.setGeneralHelp("This program assesses decompiled C code and scores on a number of aspects. It emits " +
+                "its output in HTML and/or XML format.");
+        // parse command line parameters (errors or requested help will stop the program by using exit(), so
+        // it only returns if all is well)
+        var a = me.parseCommandLineInput(args);
 
-        // check number of parameters
-        if (args.length>3){
-            printHelp();
-            System.err.println("Error: too many parameters (" + args.length + ")");
-            for (int p=0; p<args.length; p++){
-                System.err.println(p + ":" + args[p]);
-            }
-            exit(ERROR);
-        }
+        // and use parsed data
+        String strValue;
 
-        // check container folder
-        if (args.length<1){
-            // omitted --> error
-            printHelp();
-            System.err.println("Error: container folder omitted, but is a required parameter.");
-            exit(ERROR);
+        // container base folder
+        ////////////////////////
+        strValue = strGetParameterValue(STRROOTCONTAINEROPTION, a);
+        assert strValue!=null;         // should not be a problem, as the parser should hold if this required option is omitted
+        if (strValue.equals("*")){
+            cli.strContainerSourceLocation = Environment.containerBasePath;
         }
         else {
-            // use default?
-            if (args[0].equals("*")){
-                cli.strContainerSourceLocation = Environment.containerBasePath;
-            }
-            else {
-                // use argument
-                cli.strContainerSourceLocation = IOElements.strAdaptPathToMatchFileSystemAndAddSeparator(args[0]);
-            }
-            if (!IOElements.bFolderExists(cli.strContainerSourceLocation)){
-                printHelp();
-                System.err.println("Error: container folder does not exist.");
-                exit(ERROR);
-            }
+            // use argument
+            cli.strContainerSourceLocation = IOElements.strAdaptPathToMatchFileSystemAndAddSeparator(strValue);
+        }
+        if (!IOElements.bFolderExists(cli.strContainerSourceLocation)){
+            me.printError("Container base folder does not exist.", 101);
         }
 
-        // check decompiler script
-        if (args.length<2){
-            // omitted --> error
-            printHelp();
-            System.err.println("Error: decompiler script omitted, but is a required parameter.");
-            exit(ERROR);
+        // compiler script
+        //////////////////
+        strValue = strGetParameterValue(STRDECOMPILERSCRIPTOPTION, a);
+        assert strValue!=null;         // should not be a problem, as the parser should hold if this required option is omitted
+        if (!IOElements.bFileExists(strValue)){
+            me.printError("Decompiler script does not exist.", 102);
         }
-        else {
-            if (!IOElements.bFileExists(args[1])){
-                printHelp();
-                System.err.println("Error: decompiler script not found.");
-                exit(ERROR);
-            }
-            cli.strDecompilerScript = args[1];
-        }
+        cli.strDecompilerScript = strValue;
 
-        // which container is to be checked
-        if (args.length<3){
+        // container to be assessed
+        ///////////////////////////
+        strValue = strGetParameterValue(STRCONTAINERINDEXOPTION, a);
+        if (strValue==null){
             // omitted, use default
-            cli.iContainerToBeTested = -1; // a random container will be selected later on in the programm
+            cli.iContainerToBeTested = -1; // a random container will be selected later on in the program
         }
         else {
             // try to interpret
-            long val = Misc.lngRobustStringToLong(args[2], Long.MIN_VALUE);
+            long val = Misc.lngRobustStringToLong(strValue, Long.MIN_VALUE);
             if (val == Long.MIN_VALUE){
-                printHelp();
-                System.err.println("Error: conversion to number failed for container to be tested (" + args[2] + ")" );
-                exit(ERROR);
+                me.printError("Conversion to number failed for container to be tested (" + strValue + ")" );
             }
             if (val < 0 ){
-                printHelp();
-                System.err.println("Error: negative container number is not allowed (" + args[2] + "); omit arg if you want a random container");
-                exit(ERROR);
+                me.printError("Negative container number is not allowed (" + strValue + "); omit arg if you want a random container");
             }
             cli.iContainerToBeTested = (int)val;
         }
 
+        // html/xml output
+        //////////////////
+        strValue = strGetParameterValue(STRHTMLOPTION, a);
+        boolean bAnyOutput = false;
+        if (strValue!=null){
+            cli.strHTMLOutput = strValue;
+            bAnyOutput = true;
+        }
+        strValue = strGetParameterValue(STRXMLOPTION, a);
+        if (strValue!=null){
+            cli.strXMLOutput = strValue;
+            bAnyOutput = true;
+        }
+        if (!bAnyOutput){
+            cli.strHTMLOutput = Path.of(cli.strContainerSourceLocation, "report.html").toString();
+        }
+
+        // all is well, thus we can just print our own program header and go on
+        me.printProgramHeader();
     }
-
-    /**
-     * Dump help text to stdout
-     */
-    private static void printHelp(){
-        // show help and be done.
-        printProgramHeader();
-        System.out.println(
-                "This software takes up to three parameters:\n" +
-                        "container_root_folder  -- location of the root folder where all the test containers are found\n" +
-                        "                          required parameter.\n" +
-                        "decompiler_script      -- full path to a script to invoke the decompiler. The script must accept two\n" +
-                        "                          parameters, the first being the binary to be decompiled, the second being\n" +
-                        "                          the file that must contain the C output after decompilation\n" +
-                        "                          required parameter.\n" +
-                        "container_to_be_tested -- container number to be tested. If omitted, a random container is selected\n" +
-                        "                          integer value expected, decimal number, optional parameter\n" +
-                        "\n" +
-                        "running with any of the following in the argument list will produce this help:\n" +
-                        "-h, -help, -?, /h, /help, /?, all case insensitive"
-                // we do not show the hidden * option for container folder in the help screen, as it is
-                // developer specific
-        );
-    }
-
-    private static void printProgramHeader(){
-        System.out.println(
-                        "deb'm assessor\n" +
-                        "==============\n" +
-                        "\n" +
-                        "(c) 2023/2024 Jaap van den Bos, Kesava van Gelder, Reijer Klaasse\n");
-
-    }
-
-
 
 }

--- a/src/main/java/nl/ou/debm/common/CommandLineUtils.java
+++ b/src/main/java/nl/ou/debm/common/CommandLineUtils.java
@@ -1,0 +1,39 @@
+package nl.ou.debm.common;
+
+import java.util.List;
+
+public class CommandLineUtils {
+
+    static public class ParameterDefinition{
+        public String strParameterDescription="";
+        public String strPrefix="";
+        public char cCardinality='1';
+    }
+
+    static public class ParsedCommandLineParameter {
+        public String strParameterDescription = "";
+        public String strValue = "";
+    }
+
+    private String m_strProgramName = "";
+    private String m_strCopyRight = "";
+
+    public CommandLineUtils(String strProgramName, String strCopyRight){
+        m_strProgramName = strProgramName;
+        m_strCopyRight = strCopyRight;
+    }
+
+    public List<ParsedCommandLineParameter> parseCommandLineInput(String[] args){
+        return null;
+    }
+
+    public void printProgramHeader(){
+        System.out.println(m_strProgramName);
+        StringBuilder sb = new StringBuilder(m_strProgramName);
+        for (int i=0; i<sb.length(); ++i){
+            sb.setCharAt(i, '=');
+        }
+        System.out.println(sb);
+        System.out.println(m_strCopyRight);
+    }
+}

--- a/src/main/java/nl/ou/debm/common/CommandLineUtils.java
+++ b/src/main/java/nl/ou/debm/common/CommandLineUtils.java
@@ -179,8 +179,6 @@ public class CommandLineUtils {
             if (bAnyRequired) {
                 printError("no parameters given.", 6);
             }
-            printProgramHeader();
-            return out;
         }
 
         // array to list

--- a/src/main/java/nl/ou/debm/common/CommandLineUtils.java
+++ b/src/main/java/nl/ou/debm/common/CommandLineUtils.java
@@ -5,14 +5,20 @@ import java.util.List;
 
 import static java.lang.System.exit;
 
+/**
+ * This class simplifies the process of parsing command line arguments and printing help.
+ */
 public class CommandLineUtils {
 
+    /**
+     * Class to be used as a struct, describing what arguments are expected on the command line
+     */
     static public class ParameterDefinition{
-        public String strParameterDescriptionHeader="";
-        public String strParameterDescription="";
-        final public List<String> lPrefix= new ArrayList<>();
-        public char cCardinality='1';
-        public String strDefaultValue = "";
+        /** very short description of the parameter (preferably in one word) */     public String strParameterDescriptionHeader="";
+        /** full description of the option */                                       public String strParameterDescription="";
+        /** list of prefixes for this parameter (eg -i=, /i=, i:) */                final public List<String> lPrefix= new ArrayList<>();
+        /** cardinality: *=0 or more; ?=0 or 1; 1=exactly 1; +=1 or more      */    public char cCardinality='1';
+        /** default value if this argument is not present */                        public String strDefaultValue = "";
 
         public ParameterDefinition() {};
         public ParameterDefinition(String strParameterDescriptionHeader, String strParameterDescription, String strPrefix, char cCardinality){
@@ -45,9 +51,12 @@ public class CommandLineUtils {
         }
     }
 
+    /**
+     * class (struct) that describes the arguments found
+     */
     static public class ParsedCommandLineParameter {
-        public String strPrefix = "";
-        public String strValue = "";
+        /** prefix for this value (for example: -i=). Always first in the list im ParameterDefinition. */   public String strPrefix = "";
+        /** value for this prefix */                                                                        public String strValue = "";
 
         public ParsedCommandLineParameter(String strPrefix, String strValue){
             this.strPrefix = strPrefix;
@@ -61,10 +70,10 @@ public class CommandLineUtils {
     }
 
 
-    private String m_strProgramName = "";
-    private String m_strCopyRight = "";
-    private String m_strGeneralHelp = "";
-    private final  List<ParameterDefinition> m_pmd = new ArrayList<>();
+    /** program name, used in the header */         private String m_strProgramName = "";
+    /** copyright notice */                         private String m_strCopyRight = "";
+    /** general help text */                        private String m_strGeneralHelp = "";
+    /** description of the expected parameters */   private final  List<ParameterDefinition> m_pmd = new ArrayList<>();
 
     public CommandLineUtils(String strProgramName, String strCopyRight){
         m_strProgramName = strProgramName;
@@ -77,15 +86,26 @@ public class CommandLineUtils {
         setParameterDefinitions(pmd);
     }
 
+    /**
+     * set what arguments are expected by this program
+     * @param pmd parameter definitions
+     */
     public void setParameterDefinitions(List<ParameterDefinition> pmd){
         m_pmd.clear();;
         m_pmd.addAll(pmd);
     }
 
+    /**
+     * Set the text for general help.
+     * @param strGeneralHelp New general help text. Text will be auto-wrapped. \n is supported
+     */
     public void setGeneralHelp(String strGeneralHelp){
         m_strGeneralHelp=strGeneralHelp;
     }
 
+    /**
+     * Print program header: name of the program, double underline and copyright notice
+     */
     public void printProgramHeader(){
         System.out.println(m_strProgramName);
         StringBuilder sb = new StringBuilder(m_strProgramName);
@@ -96,6 +116,9 @@ public class CommandLineUtils {
         System.out.println(m_strCopyRight);
     }
 
+    /**
+     * print help text and details of all the parameters
+     */
     public void printHelp(){
         printArrangedText(m_strGeneralHelp, 80, 0);
         System.out.println("\nArguments:");
@@ -120,6 +143,12 @@ public class CommandLineUtils {
         }
     }
 
+    /**
+     * Send text to stdout and wrap it appropriately
+     * @param strText Text to print
+     * @param iWidth line width
+     * @param iTab number of spaces left of the text block
+     */
     private void printArrangedText(String strText, int iWidth, int iTab){
         var strTab = "                                                     ".substring(0, iTab);
         for (int p1=0; p1 < strText.length(); p1++){
@@ -149,9 +178,18 @@ public class CommandLineUtils {
     }
 
 
+    /**
+     * Print header, help, error message and exit program with code 1
+     * @param strError error to be printed
+     */
     public void printError(String strError) {
         printError(strError, 1);
     }
+    /**
+     * Print header, help, error message and exit program
+     * @param strError error to be printed
+     * @param iErrorNumber exit code to be used
+     */
     public void printError(String strError, int iErrorNumber){
         printProgramHeader();
         System.out.println();
@@ -161,6 +199,12 @@ public class CommandLineUtils {
         exit(iErrorNumber);
     }
 
+    /**
+     * Parse command line arguments. Checks cardinality and show the users errors when needed.
+     * Whenever errors occur, or help is shown, the program exits using exit().
+     * @param args the arguments the JVM passed to main()
+     * @return a parsed set of arguments
+     */
     public List<ParsedCommandLineParameter> parseCommandLineInput(String[] args){
         assert !m_pmd.isEmpty() : "No parameter definitions initialized";
 
@@ -246,6 +290,12 @@ public class CommandLineUtils {
         return out;
     }
 
+    /**
+     * Get a value from a list of parsed parameters. If more than one occurs, only the first found is returned
+     * @param strWhichParameter what parameter must be searched
+     * @param args table to search it in
+     * @return the value or null when not found
+     */
     public static String strGetParameterValue(String strWhichParameter, List<ParsedCommandLineParameter> args){
         for (var item : args){
             if (item.strPrefix.equals(strWhichParameter)){

--- a/src/main/java/nl/ou/debm/common/CommandLineUtils.java
+++ b/src/main/java/nl/ou/debm/common/CommandLineUtils.java
@@ -1,30 +1,61 @@
 package nl.ou.debm.common;
 
+import java.util.ArrayList;
 import java.util.List;
+
+import static java.lang.System.exit;
 
 public class CommandLineUtils {
 
     static public class ParameterDefinition{
+        public String strParameterDescriptionHeader="";
         public String strParameterDescription="";
-        public String strPrefix="";
+        final public List<String> lPrefix= new ArrayList<>();
         public char cCardinality='1';
+
+        public ParameterDefinition() {};
+        public ParameterDefinition(String strParameterDescriptionHeader, String strParameterDescription, String strPrefix, char cCardinality){
+            this.strParameterDescriptionHeader = strParameterDescriptionHeader;
+            this.strParameterDescription = strParameterDescription;
+            this.lPrefix.add(strPrefix);
+            this.cCardinality = cCardinality;
+        }
     }
 
     static public class ParsedCommandLineParameter {
         public String strParameterDescription = "";
         public String strValue = "";
+
+        public ParsedCommandLineParameter(String strParameterDescription, String strValue){
+            this.strParameterDescription = strParameterDescription;
+            this.strValue = strValue;
+        }
+
+        @Override
+        public String toString(){
+            return strParameterDescription + ":" + strValue;
+        }
     }
+
 
     private String m_strProgramName = "";
     private String m_strCopyRight = "";
+    private final  List<ParameterDefinition> m_pmd = new ArrayList<>();
 
     public CommandLineUtils(String strProgramName, String strCopyRight){
         m_strProgramName = strProgramName;
         m_strCopyRight = strCopyRight;
     }
 
-    public List<ParsedCommandLineParameter> parseCommandLineInput(String[] args){
-        return null;
+    public CommandLineUtils(String strProgramName, String strCopyRight, List<ParameterDefinition> pmd){
+        m_strProgramName = strProgramName;
+        m_strCopyRight = strCopyRight;
+        setParameterDefinitions(pmd);
+    }
+
+    public void setParameterDefinitions(List<ParameterDefinition> pmd){
+        m_pmd.clear();;
+        m_pmd.addAll(pmd);
     }
 
     public void printProgramHeader(){
@@ -36,4 +67,82 @@ public class CommandLineUtils {
         System.out.println(sb);
         System.out.println(m_strCopyRight);
     }
+
+    public void printHelp(){
+        System.out.println("HELP TEXT");
+    }
+
+    private void printError(String strError) {
+        printError(strError, 1);
+    }
+    private void printError(String strError, int iErrorNumber){
+        printProgramHeader();
+        System.out.println();
+        System.out.println("*** Error: " + strError);
+        System.out.println();
+        printHelp();
+        exit(iErrorNumber);
+    }
+
+    public List<ParsedCommandLineParameter> parseCommandLineInput(String[] args){
+        assert !m_pmd.isEmpty() : "No parameter definitions initialized";
+
+        // output
+        List<ParsedCommandLineParameter> out = new ArrayList<>(args.length);
+
+        // any parameters required?
+        boolean bAnyRequired = false;
+        for (var pd : m_pmd){
+            if ((pd.cCardinality=='1') || (pd.cCardinality=='+')){
+                bAnyRequired = true;
+                break;
+            }
+        }
+        if (args.length==0){
+            if (bAnyRequired) {
+                printError("no parameters given.");
+            }
+            printProgramHeader();
+            return out;
+        }
+
+        // array to list
+        List<String> pars = new ArrayList<>(List.of(args));
+
+        // find help argument
+        String[] HELP = { "-h", "-help", "/h", "/help", "-?", "/?"};
+        for (var a : pars){
+            for (var h : HELP){
+                if (a.trim().compareToIgnoreCase(h)==0){
+                    printProgramHeader();
+                    printHelp();
+                    exit(0);
+                }
+            }
+        }
+
+        // do all other parsing
+        while (!pars.isEmpty()){
+            boolean bFound = false;
+            for (var pm : m_pmd) {
+                for (var pf : pm.lPrefix) {
+                    if (pars.get(0).startsWith(pf)) {
+                        // found parameter!
+                        bFound = true;
+                        // copy to parsed list
+                        out.add(new ParsedCommandLineParameter(pm.lPrefix.get(0), pars.get(0).substring(pf.length())));
+                    }
+                }
+            }
+            if (!bFound){
+                printError("Parameter starts with unknown option code: " + pars.get(0),1);
+            }
+            pars.remove(0);
+        }
+
+
+        return out;
+    }
+
+
 }

--- a/src/main/java/nl/ou/debm/common/Misc.java
+++ b/src/main/java/nl/ou/debm/common/Misc.java
@@ -5,6 +5,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.*;
 import java.util.Collection;
+import java.util.Locale;
 import java.util.Random;
 
 import static java.lang.Math.abs;
@@ -31,13 +32,13 @@ public class Misc {
         if(iLength == 0)
             iLength = 1;
         // avoid negative input
-        return String.format("%1$" + iLength + "s", abs(iValue)).replace(' ', '0');
+        return String.format(Locale.ROOT, "%1$" + iLength + "s", abs(iValue)).replace(' ', '0');
     }
     public static String strGetHexNumberWithPrefixZeros(int iValue, int iLength){
         if(iLength == 0)
             iLength = 1;
         // avoid negative input
-        return String.format("%1$" + iLength + "X", abs(iValue)).replace(' ', '0');
+        return String.format(Locale.ROOT, "%1$" + iLength + "X", abs(iValue)).replace(' ', '0');
     }
 
     private static boolean bRunsOnWindows(){
@@ -268,7 +269,7 @@ public class Misc {
         if (v1==null){
             return "";
         }
-        return String.format("%.2f", 100 * v1);
+        return String.format(Locale.ROOT, "%.2f", 100 * v1);
     }
 
     /**

--- a/src/main/java/nl/ou/debm/common/ProjectSettings.java
+++ b/src/main/java/nl/ou/debm/common/ProjectSettings.java
@@ -17,4 +17,4 @@ public class ProjectSettings {
     public static final int MAX_MUTLIPLE_STATEMENTS=6;
 
     public final static int IDEFAULTNUMBEROFCONTAINERS = 50;
-    public final static int IDEFAULTTESTSPERCONTAINER = 50;}
+    public final static int IDEFAULTTESTSPERCONTAINER = 25;}

--- a/src/main/java/nl/ou/debm/common/ProjectSettings.java
+++ b/src/main/java/nl/ou/debm/common/ProjectSettings.java
@@ -16,5 +16,5 @@ public class ProjectSettings {
     public static final double CHANCE_OF_MULTIPLE_STATEMENTS=.01;
     public static final int MAX_MUTLIPLE_STATEMENTS=6;
 
-    public final static int IDEFAULTNUMBEROFCONTAINERS = 50;
-    public final static int IDEFAULTTESTSPERCONTAINER = 25;}
+    public final static int IDEFAULTNUMBEROFCONTAINERS = 25;
+    public final static int IDEFAULTTESTSPERCONTAINER = 75;}

--- a/src/main/java/nl/ou/debm/producer/Main.java
+++ b/src/main/java/nl/ou/debm/producer/Main.java
@@ -277,7 +277,8 @@ public class Main {
         pmd.add(new CommandLineUtils.ParameterDefinition(
                 "root_containers_folder",
                 "location of the root folder where all the test containers will be located. " +
-                        "If omitted, subfolder 'containers' of current folder is used.",
+                        "If omitted, subfolder 'containers' of current folder is used.\n" +
+                        "If you use *, the default setting from the class Environment is used.",
                 new String[]{STRROOTCONTAINEROPTION, "/c="}, '?'
         ));
         pmd.add(new CommandLineUtils.ParameterDefinition(

--- a/src/main/java/nl/ou/debm/producer/Main.java
+++ b/src/main/java/nl/ou/debm/producer/Main.java
@@ -13,6 +13,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import static java.lang.System.exit;
+import static nl.ou.debm.common.CommandLineUtils.strGetParameterValue;
 import static nl.ou.debm.common.ProjectSettings.IDEFAULTNUMBEROFCONTAINERS;
 import static nl.ou.debm.common.ProjectSettings.IDEFAULTTESTSPERCONTAINER;
 
@@ -179,7 +180,6 @@ public class Main {
         handleCLIParameters(args, cli);
 
         // show program name & parameters
-        printProgramHeader();
         System.out.println("Containers root folder: " + cli.strContainerDestinationLocation);
         System.out.println("Number of containers:   " + cli.iNumberOfContainers);
         System.out.println("Tests per container:    " + cli.iNumberOfTestsPerContainer);
@@ -267,117 +267,88 @@ public class Main {
      * @param cli output
      */
     private static void handleCLIParameters(String[] args, ProducerCLIParameters cli){
-        // show help if requested
-        String[] HELP = { "-h", "-help", "/h", "/help", "-?", "/?"};
-        for (var a : args){
-            for (var h : HELP){
-                if (a.trim().compareToIgnoreCase(h)==0){
-                    printHelp();
-                    exit(0);
-                }
-            }
-        }
+        // options
+        final String STRROOTCONTAINEROPTION = "-c=";
+        final String STRNCONTAINERS = "-nc=";
+        final String STRNTESTSPERCONTAINER = "-ntc=";
 
-        final int ERROR = 1;
+        // set up basic interpretation parameters
+        List<CommandLineUtils.ParameterDefinition> pmd = new ArrayList<>();
+        pmd.add(new CommandLineUtils.ParameterDefinition(
+                "root_containers_folder",
+                "location of the root folder where all the test containers will be located. " +
+                        "If omitted, subfolder 'containers' of current folder is used.",
+                new String[]{STRROOTCONTAINEROPTION, "/c="}, '?'
+        ));
+        pmd.add(new CommandLineUtils.ParameterDefinition(
+                "number_of_containers",
+                "number of containers to be produced. If omitted, " + IDEFAULTNUMBEROFCONTAINERS +
+                        " containers will be made. Integer value expected, decimal number.",
+                new String[]{STRNCONTAINERS, "/nc="}, '?', IDEFAULTNUMBEROFCONTAINERS + ""
+        ));
+        pmd.add(new CommandLineUtils.ParameterDefinition(
+                "number_of_tests_per_containers",
+                "number of tests per container. If omitted, " + IDEFAULTTESTSPERCONTAINER + "" +
+                        " tests per container will be made.",
+                new String[]{STRNTESTSPERCONTAINER, "/ntc="}, '?', IDEFAULTTESTSPERCONTAINER + ""
+        ));
+        // set up info
+        var me = new CommandLineUtils("deb'm producer",
+                "(c) 2023/2024 Jaap van den Bos, Kesava van Gelder, Reijer Klaasse",
+                pmd);
+        me.setGeneralHelp("This program produces C source codes and has these compiled to LLVM-IR and binaries.");
+        // parse command line parameters (errors or requested help will stop the program by using exit(), so
+        // it only returns if all is well)
+        var a = me.parseCommandLineInput(args);
 
-        // check number of parameters
-        if (args.length>3){
-            printHelp();
-            System.err.println("Error: too many parameters (" + args.length + ")");
-            for (int p=0; p<args.length; p++){
-                System.err.println(p + ":" + args[p]);
-            }
-            exit(ERROR);
-        }
+        // and use parsed data
+        String strValue;
 
-        // check container folder
-        if (args.length<1){
+        // container base folder
+        ////////////////////////
+        strValue = strGetParameterValue(STRROOTCONTAINEROPTION, a);
+        if (strValue==null){
             // omitted, use current folder with default subfolder
             cli.strContainerDestinationLocation = IOElements.strAdaptPathToMatchFileSystemAndAddSeparator(Environment.STRDEFAULTCONTAINERSROOTFOLDER);
         }
         else {
-            // use default?
-            if (args[0].equals("*")){
+            if (strValue.equals("*")) {
                 cli.strContainerDestinationLocation = Environment.containerBasePath;
-            }
-            else {
+            } else {
                 // use argument
-                cli.strContainerDestinationLocation = IOElements.strAdaptPathToMatchFileSystemAndAddSeparator(args[0]);
+                cli.strContainerDestinationLocation = IOElements.strAdaptPathToMatchFileSystemAndAddSeparator(strValue);
             }
         }
 
-        // check number of containers
-        if (args.length<2){
-            // omitted, use default
-            cli.iNumberOfContainers= IDEFAULTNUMBEROFCONTAINERS;
+        // check the number of containers
+        /////////////////////////////////
+        strValue = strGetParameterValue(STRNCONTAINERS, a);
+        assert strValue!=null;          // safe, as this has a default value
+        // try to interpret
+        long val = Misc.lngRobustStringToLong(strValue, Long.MIN_VALUE);
+        if (val == Long.MIN_VALUE){
+            me.printError("Conversion to number failed for number of containers (" + strValue + ")" );
         }
-        else {
-            // try to interpret
-            long val = Misc.lngRobustStringToLong(args[1], Long.MIN_VALUE);
-            if (val == Long.MIN_VALUE){
-                printHelp();
-                System.err.println("Error: conversion to number failed for number of containers (" + args[1] + ")" );
-                exit(ERROR);
-            }
-            if (val <= 0 ){
-                printHelp();
-                System.err.println("Error: number of containers must at least be 1 (" + args[1] + ")");
-                exit(ERROR);
-            }
-            cli.iNumberOfContainers = (int)val;
+        if (val <= 0 ){
+            me.printError("Number of containers must at least be 1 (" + strValue + ")");
         }
+        cli.iNumberOfContainers = (int)val;
 
-        // check tests per containers
-        if (args.length<3){
-            // omitted, use default
-            cli.iNumberOfTestsPerContainer= IDEFAULTTESTSPERCONTAINER;
+        // check the number of tests per container
+        //////////////////////////////////////////
+        strValue = strGetParameterValue(STRNTESTSPERCONTAINER, a);
+        assert strValue!=null;          // safe, as this has a default value
+        // try to interpret
+        val = Misc.lngRobustStringToLong(strValue, Long.MIN_VALUE);
+        if (val == Long.MIN_VALUE){
+            me.printError("Conversion to number failed for number of tests per container (" + strValue + ")" );
         }
-        else {
-            // try to interpret
-            long val = Misc.lngRobustStringToLong(args[2], Long.MIN_VALUE);
-            if (val == Long.MIN_VALUE){
-                printHelp();
-                System.err.println("Error: conversion to number failed for number of tests per containers (" + args[2] + ")" );
-                exit(ERROR);
-            }
-            if (val <= 0 ){
-                printHelp();
-                System.err.println("Error: number of containers must at least be 1 (" + args[2] + ")");
-                exit(ERROR);
-            }
-            cli.iNumberOfTestsPerContainer = (int)val;
+        if (val <= 0 ){
+            me.printError("Number of tests per containers must at least be 1 (" + strValue + ")");
         }
+        cli.iNumberOfTestsPerContainer = (int)val;
 
-    }
-
-    /**
-     * Dump help text to stdout
-     */
-    private static void printHelp(){
-        // show help and be done.
-        printProgramHeader();
-        System.out.println(
-                "This software takes up to three parameters:\n" +
-                "container_root_folder     -- location of the root folder where all the test containers are put\n" +
-                "                             if omitted, subfolder 'containers' of current folder is used.\n" +
-                "number_of_containers      -- number of containers to be produced. If omitted, " + IDEFAULTNUMBEROFCONTAINERS + " containers will be made\n" +
-                "                             integer value expected, decimal number\n" +
-                "number_of_tests/container -- number of tests per container. If omitted, " + IDEFAULTTESTSPERCONTAINER + " tests will be made\n" +
-                "                             integer value expected, decimal number\n" +
-                "\n" +
-                "running with any of the following in the argument list will produce this help:\n" +
-                "-h, -help, -?, /h, /help, /?, all case insensitive"
-                // we do not show the hidden * option for container folder in the help screen, as it is
-                // developer specific
-        );
-    }
-
-    private static void printProgramHeader(){
-        System.out.println(
-                "deb'm producer\n" +
-                        "==============\n" +
-                        "\n" +
-                        "(c) 2023/2024 Jaap van den Bos, Kesava van Gelder, Reijer Klaasse\n");
-
+        // program header
+        me.printProgramHeader();
     }
 }

--- a/src/main/java/nl/ou/debm/test/AggregateAndReportTest.java
+++ b/src/main/java/nl/ou/debm/test/AggregateAndReportTest.java
@@ -63,10 +63,10 @@ public class AggregateAndReportTest {
         assertEquals(LIST_SIZE*55, (int)dblActualSum(list6));
         assertEquals(LIST_SIZE*100, (int)dblHighBoundSum(list6));
 
-        Assessor.generateReport(list,"/tmp/list.html", false);
-        Assessor.generateReport(list4,"/tmp/list4.html", false);
-        Assessor.generateReport(list5,"/tmp/list5.html", false);
-        Assessor.generateReport(list6,"/tmp/list6.html", false);
+        Assessor.generateHTMLReport(list,"/tmp/list.html", false);
+        Assessor.generateHTMLReport(list4,"/tmp/list4.html", false);
+        Assessor.generateHTMLReport(list5,"/tmp/list5.html", false);
+        Assessor.generateHTMLReport(list6,"/tmp/list6.html", false);
     }
 
     private <T> void showList(List<T> list){

--- a/src/main/java/nl/ou/debm/test/CommandLineUtilsTest.java
+++ b/src/main/java/nl/ou/debm/test/CommandLineUtilsTest.java
@@ -12,7 +12,7 @@ public class CommandLineUtilsTest {
 
     @Test
     void BasicTest(){
-        String[] args = {"/i=hallo", "/i=bye", "-q=hallo2"};
+        String[] args = {"/i=hallo", "/c=bye", "-o=hallo2"};
 
         List<CommandLineUtils.ParameterDefinition> pmd = new ArrayList<>();
         pmd.add(new CommandLineUtils.ParameterDefinition("output",
@@ -24,6 +24,7 @@ public class CommandLineUtilsTest {
                         "Why, why don't you hear me? Where, where are the good times we had? Why, why do you love him? Why, why do you need hem so bad?",
                 "-o=", '1'));
         pmd.add(new CommandLineUtils.ParameterDefinition("input", "some other description", new String[]{"-i=", "/i="}, '*' ));
+        pmd.add(new CommandLineUtils.ParameterDefinition("count", "some other description (2)", new String[]{"-c=", "/c="}, '?', "default" ));
 
         var me = new CommandLineUtils("my program name", "(c) 2024 by us all", pmd);
         me.setGeneralHelp("This is a general description of the file. I don't know what to do anyway. Must write something. Romeo, oh Romeo, Oh! Where for are's't thou Romeo?");

--- a/src/main/java/nl/ou/debm/test/CommandLineUtilsTest.java
+++ b/src/main/java/nl/ou/debm/test/CommandLineUtilsTest.java
@@ -1,0 +1,15 @@
+package nl.ou.debm.test;
+
+import nl.ou.debm.common.CommandLineUtils;
+import org.junit.jupiter.api.Test;
+
+public class CommandLineUtilsTest {
+
+    @Test
+    void BasicTest(){
+        String[] args = {"-o=hallo", "-i=bye"};
+
+        var me = new CommandLineUtils("Mijn programmanaam", "mijn copyright");
+        me.printProgramHeader();
+    }
+}

--- a/src/main/java/nl/ou/debm/test/CommandLineUtilsTest.java
+++ b/src/main/java/nl/ou/debm/test/CommandLineUtilsTest.java
@@ -3,13 +3,27 @@ package nl.ou.debm.test;
 import nl.ou.debm.common.CommandLineUtils;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class CommandLineUtilsTest {
 
     @Test
     void BasicTest(){
         String[] args = {"-o=hallo", "-i=bye"};
 
-        var me = new CommandLineUtils("Mijn programmanaam", "mijn copyright");
-        me.printProgramHeader();
+        List<CommandLineUtils.ParameterDefinition> pmd = new ArrayList<>();
+        pmd.add(new CommandLineUtils.ParameterDefinition("output",
+                "This is a long description of the output. We try to make it such at there will be line breaks in the actual output. Would we succeed?",
+                "-o=", '1'));
+        pmd.add(new CommandLineUtils.ParameterDefinition("input", "some other description", "-i=", '*' ));
+
+        var me = new CommandLineUtils("my program name", "(c) 2024 by us all", pmd);
+
+        var q = me.parseCommandLineInput(args);
+
+        for (var item : q){
+            System.out.println(item.toString());
+        }
     }
 }

--- a/src/main/java/nl/ou/debm/test/CommandLineUtilsTest.java
+++ b/src/main/java/nl/ou/debm/test/CommandLineUtilsTest.java
@@ -6,22 +6,31 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 public class CommandLineUtilsTest {
 
     @Test
     void BasicTest(){
-        String[] args = {"-o=hallo", "-i=bye"};
+        String[] args = {"/i=hallo", "/i=bye", "-q=hallo2"};
 
         List<CommandLineUtils.ParameterDefinition> pmd = new ArrayList<>();
         pmd.add(new CommandLineUtils.ParameterDefinition("output",
-                "This is a long description of the output. We try to make it such at there will be line breaks in the actual output. Would we succeed?",
+                "This is a long description of the output. We try to make it such at there will " +
+                        "be line breaks in the actual output. Would we succeed? " +
+                        "I think we actually will. Which would be very nice\n " +
+                        "This is a linefee fed line\n" +
+                        "And this is another one\n" +
+                        "Why, why don't you hear me? Where, where are the good times we had? Why, why do you love him? Why, why do you need hem so bad?",
                 "-o=", '1'));
-        pmd.add(new CommandLineUtils.ParameterDefinition("input", "some other description", "-i=", '*' ));
+        pmd.add(new CommandLineUtils.ParameterDefinition("input", "some other description", new String[]{"-i=", "/i="}, '*' ));
 
         var me = new CommandLineUtils("my program name", "(c) 2024 by us all", pmd);
+        me.setGeneralHelp("This is a general description of the file. I don't know what to do anyway. Must write something. Romeo, oh Romeo, Oh! Where for are's't thou Romeo?");
 
         var q = me.parseCommandLineInput(args);
 
+        assertNotNull(q);
         for (var item : q){
             System.out.println(item.toString());
         }

--- a/src/main/java/nl/ou/debm/test/QuickAssessorTest.java
+++ b/src/main/java/nl/ou/debm/test/QuickAssessorTest.java
@@ -66,11 +66,14 @@ public class QuickAssessorTest {
         final int[] feat = {1, 4};
 
         StringBuilder h = new StringBuilder(), c = null, f = new StringBuilder();
+        StringBuilder xmlh = new StringBuilder(), xmlc = null, xmlf = new StringBuilder();
         Assessor.getHTMLHeaderAndFooter(h, f);
+        Assessor.getXMLHeaderAndFooter(xmlh, xmlf);
         for (int opt = 0; opt<1; opt++){
             for (var i : deci){
                 c = AssessOneSingleBinary(STR_ARCH[0], STR_OPT[opt], STR_DECOMPILER[i], feat);
                 h.append(c).append("<br><br>");
+
             }
         }
         h.append(f);
@@ -84,7 +87,8 @@ public class QuickAssessorTest {
         catch (Exception ignore){}
     }
 
-    private StringBuilder AssessOneSingleBinary(final String STR_ARCH, final String STR_OPT, final String STR_DECOMPILER, final int[] feat){
+    private void AssessOneSingleBinary(final String STR_ARCH, final String STR_OPT, final String STR_DECOMPILER, final int[] feat,
+                                                StringBuilder html, StringBuilder xml){
 
         final String STR_C_DECOMPILED = strTestSetPath() + "binary_" + STR_ARCH + "_cln_" + STR_OPT + ".exe---" + STR_DECOMPILER + ".c";
         final String STR_LLVM_COMPILED = strTestSetPath() +  "llvm_" + STR_ARCH + "_cln_" + STR_OPT + ".ll";
@@ -141,6 +145,6 @@ public class QuickAssessorTest {
         pars.put("C decompiled", STR_C_DECOMPILED);
         pars.put("LLVM compiled", STR_LLVM_COMPILED);
 
-        return Assessor.generateReport(pars, q, false);
+        return Assessor.generateHTMLReport(pars, q, false);
     }
 }

--- a/src/main/java/nl/ou/debm/test/QuickAssessorTest.java
+++ b/src/main/java/nl/ou/debm/test/QuickAssessorTest.java
@@ -62,23 +62,26 @@ public class QuickAssessorTest {
                                         "retdec",               // 4
                                         "snowman-online"};      // 5
 
-        final int[] deci = {0, 1, 2, 3, 4, 5};
+        final int[] deci = {1, 2, 3, 4};
         final int[] feat = {1, 4};
 
-        StringBuilder h = new StringBuilder(), c = null, f = new StringBuilder();
-        StringBuilder xmlh = new StringBuilder(), xmlc = null, xmlf = new StringBuilder();
+        StringBuilder h = new StringBuilder(), c = new StringBuilder(), f = new StringBuilder();
+        StringBuilder xmlh = new StringBuilder(), xmlc = new StringBuilder(), xmlf = new StringBuilder();
         Assessor.getHTMLHeaderAndFooter(h, f);
         Assessor.getXMLHeaderAndFooter(xmlh, xmlf);
         for (int opt = 0; opt<1; opt++){
             for (var i : deci){
-                c = AssessOneSingleBinary(STR_ARCH[0], STR_OPT[opt], STR_DECOMPILER[i], feat);
+                AssessOneSingleBinary(STR_ARCH[0], STR_OPT[opt], STR_DECOMPILER[i], feat, c, xmlc);
                 h.append(c).append("<br><br>");
-
+                xmlh.append(xmlc);
             }
         }
         h.append(f);
+        xmlh.append(xmlf);
 
-        var strFilename = "/home/jaap/VAF/containers/output.html";
+        var strFilename = "/home/jaap/VAF/containers/output.xml";
+        IOElements.writeToFile(xmlh, strFilename);
+        strFilename = "/home/jaap/VAF/containers/output.html";
         IOElements.writeToFile(h, strFilename);
 
         try {
@@ -145,6 +148,8 @@ public class QuickAssessorTest {
         pars.put("C decompiled", STR_C_DECOMPILED);
         pars.put("LLVM compiled", STR_LLVM_COMPILED);
 
-        return Assessor.generateHTMLReport(pars, q, false);
+        html.setLength(0); html.append(Assessor.generateHTMLReport(pars, q, false));
+        xml.setLength(0); xml.append(Assessor.generateXMLReport(pars, q, true));
+
     }
 }

--- a/src/main/java/nl/ou/debm/test/TestCategoriesTest.java
+++ b/src/main/java/nl/ou/debm/test/TestCategoriesTest.java
@@ -1,0 +1,20 @@
+package nl.ou.debm.test;
+
+import nl.ou.debm.assessor.ETestCategories;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class TestCategoriesTest {
+
+    @Test
+    void UniversalIdentifierUniqueness(){
+        for (var c1 : ETestCategories.values()){
+            for (var c2 : ETestCategories.values()){
+                if (c1!=c2){
+                    assertNotEquals(c1.lngUniversalIdentifier(), c2.lngUniversalIdentifier());
+                }
+            }
+        }
+    }
+}

--- a/xml/output.dtd
+++ b/xml/output.dtd
@@ -1,0 +1,29 @@
+<!DOCTYPE tables PUBLIC "-//DEBM//EN" "https://raw.githubusercontent.com/reijer-dev/decompiler-benchmarking/master/xml/output.dtd">
+<!-- this DTD defines the xml output the assessor emits -->
+<!ELEMENT tables (table+)>
+    <!ELEMENT table (tableproperty*, testresult+)>
+        <!ELEMENT tableproperty (propname, propvalue)>
+            <!ELEMENT propname (#PCDATA)>
+            <!ELEMENT propvalue (#PCDATA)>
+        <!ELEMENT testresult (testid,
+                              testdescription?,
+                              testunit?,
+                              architecture?,
+                              compiler?,
+                              optimization?,
+                              minvalue?,
+                              actualvalue,
+                              maxvalue?,
+                              targetvalue?,
+                              testcount?)>
+            <!ELEMENT testid (#PCDATA)>
+            <!ELEMENT testdescription (#PCDATA)>
+            <!ELEMENT testunit (#PCDATA)>
+            <!ELEMENT architecture (#PCDATA)>
+            <!ELEMENT compiler (#PCDATA)>
+            <!ELEMENT optimization (#PCDATA)>
+            <!ELEMENT minvalue (#PCDATA)>
+            <!ELEMENT actualvalue (#PCDATA)>
+            <!ELEMENT maxvalue (#PCDATA)>
+            <!ELEMENT targetvalue (#PCDATA)>
+            <!ELEMENT testcount (#PCDATA)>

--- a/xml/output.dtd
+++ b/xml/output.dtd
@@ -1,6 +1,6 @@
-<!DOCTYPE tables PUBLIC "-//DEBM//EN" "https://raw.githubusercontent.com/reijer-dev/decompiler-benchmarking/master/xml/output.dtd">
+<!DOCTYPE debm PUBLIC "-//DEBM//EN" "https://raw.githubusercontent.com/reijer-dev/decompiler-benchmarking/master/xml/output.dtd">
 <!-- this DTD defines the xml output the assessor emits -->
-<!ELEMENT tables (table+)>
+<!ELEMENT debm (table+)>
     <!ELEMENT table (tableproperty*, testresult+)>
         <!ELEMENT tableproperty (propname, propvalue)>
             <!ELEMENT propname (#PCDATA)>


### PR DESCRIPTION
## big changes
- refactored parsing the command line parameters the assessor or producer is given by the jvm; **this also means all parameters now need prefixes, such as -c=** (-c=/location/of/container/basefolder);
- added XML output option.
## rationale
To enable further scripting by researchers, it is possible to emit xml output and have the xml/html output put in a place of your own choice. The xml gives info per test, such as a unique test code that should never change in future versions.
## smaller changes
- xml or html output files from the assessor can be put anywhere
- changed the ',' in decimal point outputs to '.' (our output is in English)
- added unique ID's in the test enumeration (emitted in the xml)
- set default number of contairs to produce to 50, and tests per containers defaults to 25
- wrote DTD for the xml output