### PR TITLE
Set margin to high-low when high=target

### DIFF
--- a/src/main/java/nl/ou/debm/common/Misc.java
+++ b/src/main/java/nl/ou/debm/common/Misc.java
@@ -322,38 +322,29 @@ public class Misc {
         // determine to compare up or down
         double margin = 0.0;
         double diff = 0.0;
+        diff = Math.abs(dblTargetValue - dblActualValue);
         if (dblActualValue > dblTargetValue){
             // find pct in range target-upper bound
-            if (dblHighBound==null){
-                // no higher bound, done
+            if (dblHighBound==null)
                 return null;
-            }
-            assert dblActualValue <= dblHighBound : "Actual value is greater than high bound";
             margin = dblHighBound - dblTargetValue;
-            if(margin == 0)
-                margin = dblHighBound - dblLowBound;
-            diff = dblHighBound - dblActualValue;
         }
         else {
             // find pct in range upper bound-target
-            if (dblLowBound==null){
-                // no lower bound, done
+            if (dblLowBound==null)
                 return null;
-            }
-            assert dblLowBound <= dblActualValue : "Actual value is smaller than low bound";
             margin = dblTargetValue - dblLowBound;
-            if(margin == 0)
-                margin = dblHighBound - dblLowBound;
-            diff = dblActualValue - dblLowBound;
         }
-        // no marin, then done
-        if (margin == 0){
+        if (margin == 0)
+            margin = dblHighBound - dblLowBound;
+        // no margin, then done
+        if (margin == 0)
             return null;
-        }
+
         // We want a 100% score in the table to be errorless
         // sometimes the margin is so big, that rounded up a non-100%-score gets to be displayed
         // as 100%. We make sure that doesn't happen.
-        var res = diff / margin;
+        var res = 1 - diff / margin;
         return ((res>0.9999) && (res<1.0)) ? 0.9999 : res;
     }
 

--- a/src/main/java/nl/ou/debm/common/Misc.java
+++ b/src/main/java/nl/ou/debm/common/Misc.java
@@ -330,6 +330,8 @@ public class Misc {
             }
             assert dblActualValue <= dblHighBound : "Actual value is greater than high bound";
             margin = dblHighBound - dblTargetValue;
+            if(margin == 0)
+                margin = dblHighBound - dblLowBound;
             diff = dblHighBound - dblActualValue;
         }
         else {
@@ -340,6 +342,8 @@ public class Misc {
             }
             assert dblLowBound <= dblActualValue : "Actual value is smaller than low bound";
             margin = dblTargetValue - dblLowBound;
+            if(margin == 0)
+                margin = dblHighBound - dblLowBound;
             diff = dblActualValue - dblLowBound;
         }
         // no marin, then done

--- a/src/main/java/nl/ou/debm/common/Misc.java
+++ b/src/main/java/nl/ou/debm/common/Misc.java
@@ -314,37 +314,75 @@ public class Misc {
             // no target value -- be done
             return null;
         }
-        // return 1 if all is well
+        // check higher bound is higher or equal than lower bound
+        if ((dblLowBound!=null) && (dblHighBound!=null) && (dblHighBound<dblLowBound)){
+            throw new RuntimeException("high bound (" + dblHighBound + ") is lower than low bound (" + dblLowBound + ")");
+        }
+
+        // return 1 if actual = target
         if (dblActualValue.equals(dblTargetValue)){
             return 1.0;
         }
 
-        // determine to compare up or down
+        // check if the actual value exceeds bounds
+        if ((dblHighBound!=null) && (dblActualValue>dblHighBound)){
+            // only accept if target=highbound
+            if (!dblTargetValue.equals(dblHighBound)){
+                throw new RuntimeException("actual value (" + dblActualValue + ") exceeds high bound (" + dblHighBound + "), target!=high bound");
+            }
+            // recalculate value, only possible if low bound is set
+            if (dblLowBound==null){
+                throw new RuntimeException("actual value (" + dblActualValue + ") exceeds high bound (" + dblHighBound + "), no lower bound set");
+            }
+            dblActualValue = dblHighBound - (dblActualValue - dblHighBound);
+            // make sure not below lower bound
+            if (dblActualValue < dblLowBound){
+                dblActualValue = dblLowBound;
+            }
+        }
+        if ((dblLowBound!=null) && (dblActualValue<dblLowBound)){
+            // only accept if target=low bound
+            if (!dblTargetValue.equals(dblLowBound)){
+                throw new RuntimeException("actual value (" + dblActualValue + ") below low bound (" + dblLowBound + "), target!=low bound");
+            }
+            // recalculate value, only possible if high bound is set
+            if (dblHighBound==null){
+                throw new RuntimeException("actual value (" + dblActualValue + ") below low bound (" + dblLowBound + "), no high bound set");
+            }
+            dblActualValue = dblLowBound + (dblLowBound - dblActualValue);
+            // make sure not above lower bound
+            if (dblActualValue > dblHighBound){
+                dblActualValue = dblHighBound;
+            }
+        }
+
+        // return null if actual > target and no upper bound is set
+        //             if actual < target and no lower bound is set
+        // in these cases, we have no margin to relate to
+        if (((dblActualValue>dblTargetValue) && (dblHighBound == null)) ||
+            ((dblActualValue<dblTargetValue) && (dblLowBound == null))) {
+            return null;
+        }
+
+        // by now, we have a value that is always either between lower and target of between target and higher
         double margin = 0.0;
         double diff = 0.0;
-        diff = Math.abs(dblTargetValue - dblActualValue);
-        if (dblActualValue > dblTargetValue){
-            // find pct in range target-upper bound
-            if (dblHighBound==null)
-                return null;
-            margin = dblHighBound - dblTargetValue;
-        }
-        else {
-            // find pct in range upper bound-target
-            if (dblLowBound==null)
-                return null;
+        if (dblActualValue < dblTargetValue){
+            diff = dblActualValue - dblLowBound;
             margin = dblTargetValue - dblLowBound;
         }
-        if (margin == 0)
-            margin = dblHighBound - dblLowBound;
-        // no margin, then done
-        if (margin == 0)
-            return null;
+        else if (dblActualValue > dblTargetValue) {
+            diff = dblHighBound - dblActualValue;
+            margin = dblHighBound - dblTargetValue;
+        }
+        // no equal, because equality was filtered out way before
+        // however, if we do not use the else-if, then the compiler complains that dblHighbound might be null
+        // which is annoying (and wrong)
 
         // We want a 100% score in the table to be errorless
         // sometimes the margin is so big, that rounded up a non-100%-score gets to be displayed
         // as 100%. We make sure that doesn't happen.
-        var res = 1 - diff / margin;
+        var res = diff / margin;
         return ((res>0.9999) && (res<1.0)) ? 0.9999 : res;
     }
 

--- a/src/main/java/nl/ou/debm/test/MiscTest.java
+++ b/src/main/java/nl/ou/debm/test/MiscTest.java
@@ -284,9 +284,9 @@ class MiscTest {
     public void FractionTest(){
         double low=10, high=30, target=25;
 
-        assertThrows(AssertionError.class, () -> { Misc.dblGetFraction(low, 9.0, high, target);  });
-        assertThrows(AssertionError.class, () -> { Misc.dblGetFraction(low, 31.0, high, target);  });
-        assertThrows(AssertionError.class, () -> { Misc.dblGetFraction(high, 15.0, low, target);  });
+        assertThrows(RuntimeException.class, () -> { Misc.dblGetFraction(high, 15.0, low, target);  });
+        assertThrows(RuntimeException.class, () -> { Misc.dblGetFraction(high, 9.0, low, target);  });
+        assertThrows(RuntimeException.class, () -> { Misc.dblGetFraction(high, 31.0, low, target);  });
 
         assertEquals(1, Misc.dblGetFraction(low, 25.0, high, target));
         assertEquals((10.0/15.0), Misc.dblGetFraction(low, 20.0, high, target));
@@ -309,6 +309,67 @@ class MiscTest {
         assertEquals("", Misc.strGetPercentage(low,null, high, null));
         assertEquals("", Misc.strGetPercentage(null,15.0, high, target));
         assertEquals("", Misc.strGetPercentage(low,27.0, null, target));
+
+        double l2=0, t2=6, h2=10;
+        assertThrows(RuntimeException.class, () -> { Misc.dblGetFraction(l2, -2.0, h2, t2); });
+        assertThrows(RuntimeException.class, () -> { Misc.dblGetFraction(l2, 12.0, h2, t2); });
+        assertEquals((0.0/6.0), Misc.dblGetFraction(l2, 0.0, h2, t2));
+        assertEquals((2.0/6.0), Misc.dblGetFraction(l2, 2.0, h2, t2));
+        assertEquals((1.0), Misc.dblGetFraction(l2, 6.0, h2, t2));
+        assertEquals((2.0/4.0), Misc.dblGetFraction(l2, 8.0, h2, t2));
+        assertEquals((1.0/4.0), Misc.dblGetFraction(l2, 9.0, h2, t2));
+        assertEquals((0.0/4.0), Misc.dblGetFraction(l2, 10.0, h2, t2));
+
+        double l3=0, t3=10, h3=10;
+        assertThrows(RuntimeException.class, () -> { Misc.dblGetFraction(l3, -1.0, h3, t3); });
+        assertEquals((0.0/10.0), Misc.dblGetFraction(l3, 0.0, h3, t3));
+        assertEquals((3.0/10.0), Misc.dblGetFraction(l3, 3.0, h3, t3));
+        assertEquals((5.0/10.0), Misc.dblGetFraction(l3, 5.0, h3, t3));
+        assertEquals((9.0/10.0), Misc.dblGetFraction(l3, 9.0, h3, t3));
+        assertEquals((1.0), Misc.dblGetFraction(l3, 10.0, h3, t3));
+        assertEquals((9.0/10.0), Misc.dblGetFraction(l3, 11.0, h3, t3));
+        assertEquals((1.0/10.0), Misc.dblGetFraction(l3, 19.0, h3, t3));
+        assertEquals((0.0/10.0), Misc.dblGetFraction(l3, 20.0, h3, t3));
+        assertEquals((0.0/10.0), Misc.dblGetFraction(l3, 200.0, h3, t3));
+
+        double l4=0, t4=10;
+        Double h4 = null;
+        assertThrows(RuntimeException.class, () -> { Misc.dblGetFraction(l4, -1.0, h4, t4); });
+        assertEquals((0.0/10.0), Misc.dblGetFraction(l4, 0.0, h4, t4));
+        assertEquals((3.0/10.0), Misc.dblGetFraction(l4, 3.0, h4, t4));
+        assertEquals((5.0/10.0), Misc.dblGetFraction(l4, 5.0, h4, t4));
+        assertEquals((9.0/10.0), Misc.dblGetFraction(l4, 9.0, h4, t4));
+        assertEquals((1.0), Misc.dblGetFraction(l4, 10.0, h4, t4));
+        assertNull(dblGetFraction(l4, 11.0, h4, t4));
+        assertNull(dblGetFraction(l4, 19.0, h4, t4));
+        assertNull(dblGetFraction(l4, 20.0, h4, t4));
+        assertNull(dblGetFraction(l4, 200.0, h4, t4));
+
+        double l5=0, t5=0, h5=10;
+        assertThrows(RuntimeException.class, () -> { Misc.dblGetFraction(l5, 11.0, h5, t5); });
+        assertEquals((1.0), Misc.dblGetFraction(l5, 0.0, h5, t5));
+        assertEquals((7.0/10.0), Misc.dblGetFraction(l5, 3.0, h5, t5));
+        assertEquals((5.0/10.0), Misc.dblGetFraction(l5, 5.0, h5, t5));
+        assertEquals((1.0/10.0), Misc.dblGetFraction(l5, 9.0, h5, t5));
+        assertEquals((0.0/10.0), Misc.dblGetFraction(l5, 10.0, h5, t5));
+        assertEquals((9.0/10.0), Misc.dblGetFraction(l5, -1.0, h5, t5));
+        assertEquals((1.0/10.0), Misc.dblGetFraction(l5, -9.0, h5, t5));
+        assertEquals((0.0/10.0), Misc.dblGetFraction(l5, -10.0, h5, t5));
+        assertEquals((0.0/10.0), Misc.dblGetFraction(l5, -200.0, h5, t5));
+
+        double t6=0, h6=10;
+        Double l6 = null;
+        assertThrows(RuntimeException.class, () -> { Misc.dblGetFraction(l6, 11.0, h6, t6); });
+        assertEquals((1.0), Misc.dblGetFraction(l6, 0.0, h6, t6));
+        assertEquals((7.0/10.0), Misc.dblGetFraction(l6, 3.0, h6, t6));
+        assertEquals((5.0/10.0), Misc.dblGetFraction(l6, 5.0, h6, t6));
+        assertEquals((1.0/10.0), Misc.dblGetFraction(l6, 9.0, h6, t6));
+        assertEquals((0.0/10.0), Misc.dblGetFraction(l6, 10.0, h6, t6));
+        assertNull(dblGetFraction(l6, -1.0, h6, t6));
+        assertNull(dblGetFraction(l6, -9.0, h6, t6));
+        assertNull(dblGetFraction(l6, -10.0, h6, t6));
+        assertNull(dblGetFraction(l6, -200.0, h6, t6));
+
     }
 
     @Test


### PR DESCRIPTION
Het ging hier nog mis als de waarde hoger is dan de highbound.
Dit komt omdat de functie geen logische berekening deed.
diff was eigenlijk de echte score, en die werd gereturnd.
Nu is diff het verschil met wat het moet zijn, en dat wordt dus van 1 afgetrokken. Alle waardes blijven gelijk, alleen waar de score hoger is dan de high bound, is hij nu ook logisch.